### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,7 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
 add_subdirectory(src)
 
 
-
-if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64")
-  set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/Bin/glslangValidator.exe")
-else()
-  set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/Bin32/glslangValidator.exe")
-endif()
+find_program(GLSL_VALIDATOR glslangValidator HINTS /usr/bin /usr/local/bin $ENV{VULKAN_SDK}/Bin/ $ENV{VULKAN_SDK}/Bin32/)
 
 ## find all the shader files under the shaders folder
 file(GLOB_RECURSE GLSL_SOURCE_FILES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(vulkan_guide
 
 set_property(TARGET vulkan_guide PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:vulkan_guide>")
 
+target_include_directories(vulkan_guide PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(vulkan_guide vkbootstrap vma glm tinyobjloader imgui stb_image)
 
 target_link_libraries(vulkan_guide Vulkan::Vulkan sdl2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,17 @@
 
 # Add source to this project's executable.
-add_executable (vulkan_guide 
-"main.cpp"
-"vk_engine.cpp"
- "vk_engine.h" 
- "vk_types.h" 
- "vk_initializers.cpp" 
- "vk_initializers.h")
+add_executable(vulkan_guide
+    main.cpp
+    vk_engine.cpp
+    vk_engine.h
+    vk_types.h
+    vk_initializers.cpp
+    vk_initializers.h)
 
 
 set_property(TARGET vulkan_guide PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:vulkan_guide>")
 
-target_include_directories(vulkan_guide PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-
-target_link_libraries(vulkan_guide  vkbootstrap vma glm tinyobjloader imgui stb_image)
+target_link_libraries(vulkan_guide vkbootstrap vma glm tinyobjloader imgui stb_image)
 
 target_link_libraries(vulkan_guide Vulkan::Vulkan sdl2)
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -9,48 +9,48 @@ add_library(stb_image INTERFACE)
 add_library(tinyobjloader STATIC)
 
 target_sources(vkbootstrap PRIVATE 
-    "${CMAKE_CURRENT_SOURCE_DIR}/vkbootstrap/VkBootstrap.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/vkbootstrap/VkBootstrap.cpp"
-)
+    vkbootstrap/VkBootstrap.h
+    vkbootstrap/VkBootstrap.cpp
+    )
 
-target_include_directories(vkbootstrap PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/vkbootstrap" )
-target_link_libraries(vkbootstrap PUBLIC Vulkan::Vulkan)
+target_include_directories(vkbootstrap PUBLIC vkbootstrap)
+target_link_libraries(vkbootstrap PUBLIC Vulkan::Vulkan dl)
 
 #both vma and glm and header only libs so we only need the include path
-target_include_directories(vma INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/vma" )
-
-target_include_directories(glm INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/glm" )
+target_include_directories(vma INTERFACE vma)
+target_include_directories(glm INTERFACE glm)
 
 target_sources(tinyobjloader PRIVATE 
-    "${CMAKE_CURRENT_SOURCE_DIR}/tinyobjloader/tiny_obj_loader.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/tinyobjloader/tiny_obj_loader.cc"
-)
+    tinyobjloader/tiny_obj_loader.h
+    tinyobjloader/tiny_obj_loader.cc
+    )
 
-target_include_directories(tinyobjloader PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/tinyobjloader" )
+target_include_directories(tinyobjloader PUBLIC tinyobjloader)
 
-set(sdl2_DIR "SDL_PATH" CACHE FILEPATH "Path to SDL2")
+
+find_package(SDL2) # Find SDL via installed cmake config files (i.e. on linux)
+set(sdl2_DIR "SDL_PATH" CACHE FILEPATH "Path to SDL2") # or by manually specifying the SDL path
 add_library(sdl2 INTERFACE)
-target_include_directories(sdl2 INTERFACE "${sdl2_DIR}/include" "${sdl2_image_DIR}/include" )
+target_include_directories(sdl2 INTERFACE ${SDL2_INCLUDE_DIRS} "${sdl2_DIR}/include" "${sdl2_image_DIR}/include" )
 target_link_directories(sdl2 INTERFACE "${sdl2_DIR}/lib/x64" "${sdl2_image_DIR}/lib/x64")
 target_link_libraries(sdl2 INTERFACE SDL2 SDL2main)
 
 add_library(imgui STATIC)
 
-target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/imgui")
+target_include_directories(imgui PUBLIC imgui)
 
 target_sources(imgui PRIVATE 
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui.h"
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui.cpp"
+    imgui/imgui.h
+    imgui/imgui.cpp
 
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_demo.cpp"
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_draw.cpp"
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_widgets.cpp"
+    imgui/imgui_demo.cpp
+    imgui/imgui_draw.cpp
+    imgui/imgui_widgets.cpp
 
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_impl_vulkan.cpp"
-"${CMAKE_CURRENT_SOURCE_DIR}/imgui/imgui_impl_sdl.cpp"
-)
+    imgui/imgui_impl_vulkan.cpp
+    imgui/imgui_impl_sdl.cpp
+    )
 
 target_link_libraries(imgui PUBLIC Vulkan::Vulkan sdl2)
 
-
-target_include_directories(stb_image INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/stb_image" )
+target_include_directories(stb_image INTERFACE stb_image)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,7 +14,7 @@ target_sources(vkbootstrap PRIVATE
     )
 
 target_include_directories(vkbootstrap PUBLIC vkbootstrap)
-target_link_libraries(vkbootstrap PUBLIC Vulkan::Vulkan dl)
+target_link_libraries(vkbootstrap PUBLIC Vulkan::Vulkan $<$<BOOL:UNIX>:${CMAKE_DL_LIBS}>)
 
 #both vma and glm and header only libs so we only need the include path
 target_include_directories(vma INTERFACE vma)


### PR DESCRIPTION
CMAKE_CURRENT_SOURCE_DIR is not necessary in the dedicated target attribute
functions of cmake. Cmake will suffix any path token with the current
source path.

find_program is a useful utility to pick up binaries.

When SDL is installed the include path directives will not work - to mitigate
this problem on linux system the find_library(sdl2) is used. It lacks the
REQUIRED token - so users can still set a manually built a non-system SDL