### PR TITLE
update imageview subresource access mask

### DIFF
--- a/docs/chapter-5/loading_images.md
+++ b/docs/chapter-5/loading_images.md
@@ -248,7 +248,7 @@ void VulkanEngine::load_images()
 	
 	vkutil::load_image_from_file(*this, "../../assets/lost_empire-RGBA.png", lostEmpire.image);
 	
-	VkImageViewCreateInfo imageinfo = vkinit::imageview_create_info(VK_FORMAT_R8G8B8A8_UNORM, lostEmpire.image._image, 0);
+	VkImageViewCreateInfo imageinfo = vkinit::imageview_create_info(VK_FORMAT_R8G8B8A8_UNORM, lostEmpire.image._image, VK_IMAGE_ASPECT_COLOR_BIT);
 	vkCreateImageView(_device, &imageinfo, nullptr, &lostEmpire.imageView);
 
 	_loadedTextures["empire_diffuse"] = lostEmpire;


### PR DESCRIPTION
The spec states about `VkImageSubresouceRange`

> aspectMask must not be 0

The last parameter in `vkinit::imageview_create_info` populates `VkImageSubresouceRange::aspectMask` in the create info of the image view.