### PR TITLE
Add apostrophes to contractions

### DIFF
--- a/_posts/2020-06-08-post-libraries.md
+++ b/_posts/2020-06-08-post-libraries.md
@@ -19,7 +19,7 @@ tags:
 For the Vulkan engine, we use a specific folder layout.
 
 - `/assets` will contain textures and 3d models that we use over the guide
-- `/bin` is where the executables will get built. We dont use the normal CMake build folders to simplify the paths to assets and shaders
+- `/bin` is where the executables will get built. We don't use the normal CMake build folders to simplify the paths to assets and shaders
 - `/shaders` will contain all our shaders, and their compiled SPIR-V output
 - `/src` contains the source code for the main application and engine
 - `/third_party` contains all of the libraries we use, vendored in
@@ -28,11 +28,11 @@ For the Vulkan engine, we use a specific folder layout.
 
 On the engine, we use a set of libraries, most stored in `/third_party`. The only library that isnt vendored-in is SDL
 
-All the libraries in third-party are vendored in, and Cmake will build them automatically. For SDL, its required to build it separated from the project, and tell Cmake where to find it.
+All the libraries in third-party are vendored in, and Cmake will build them automatically. For SDL, it's required to build it separated from the project, and tell Cmake where to find it.
 
-- [GLM (openGL Mathematics)](https://github.com/g-truc/glm) Mathematics library, Header only. We use this library to use its matrix and vector math functionality. Its a library that contains types that are directly compatible with GLSL types in most cases. For example, a `glm::mat4` has similar operations and is directly compatible with a `mat4` in a shader. It says OpenGL in the name, but it works great with Vulkan too.
-- [SDL](https://www.libsdl.org/) Windowing and input library, Separate build. SDL is one of the most used libraries to create a window and have input on a crossplatform way. SDL works in almost every platform, and its generally very well supported. Used in Unreal Engine, Unity, Source, and others. We use it in the project to have a easy and fast way to open a window, and have detailed keyboard input.
-- [dear IMGUI](https://github.com/ocornut/imgui) Easy to use inmediate User-Interface library. This library allows us to create editable widgets such as sliders and windows for user interface. Its widely used in the game industry for debug tools. On the project, we use it to create interactive options for the rendering.
+- [GLM (openGL Mathematics)](https://github.com/g-truc/glm) Mathematics library, Header only. We use this library to use its matrix and vector math functionality. It's a library that contains types that are directly compatible with GLSL types in most cases. For example, a `glm::mat4` has similar operations and is directly compatible with a `mat4` in a shader. It says OpenGL in the name, but it works great with Vulkan too.
+- [SDL](https://www.libsdl.org/) Windowing and input library, Separate build. SDL is one of the most used libraries to create a window and have input on a crossplatform way. SDL works in almost every platform, and it's generally very well supported. Used in Unreal Engine, Unity, Source, and others. We use it in the project to have a easy and fast way to open a window, and have detailed keyboard input.
+- [dear IMGUI](https://github.com/ocornut/imgui) Easy to use inmediate User-Interface library. This library allows us to create editable widgets such as sliders and windows for user interface. It's widely used in the game industry for debug tools. On the project, we use it to create interactive options for the rendering.
 
 - [STB Image](https://github.com/nothings/stb) Image load library, header only. Small and easy to use library to load image files. It can load a few common formats such as BMP, PNG, JPEG, and others. Part of a set of other similar single-file libraries.
 

--- a/docs/chapter-0/code_walkthrough.md
+++ b/docs/chapter-0/code_walkthrough.md
@@ -105,7 +105,7 @@ As with vk_init, we include vk_types. We already need a Vulkan type in VkExtent2
 The Vulkan engine will be the core of everything we will be doing.
 We have a flag to know if the engine is initialized, a frame number integer (very useful!), and the size of the window we are going to open, in pixels. 
 
-The declaration `struct SDL_Window* _window;` is of special interest. Note the `struct` at the beginning. This is called a forward-declaration, and its what allows us to have the `SDL_Window `pointer in the class, without including SDL on the Vulkan engine header. This variable holds the window that we create for the application.
+The declaration `struct SDL_Window* _window;` is of special interest. Note the `struct` at the beginning. This is called a forward-declaration, and it's what allows us to have the `SDL_Window `pointer in the class, without including SDL on the Vulkan engine header. This variable holds the window that we create for the application.
 
 With the header seen, let's go to the cpp files.
 
@@ -165,7 +165,7 @@ void VulkanEngine::cleanup()
 }
 ```
 In a similar way that we did `SDL_CreateWindow`, we need to do `SDL_DestroyWindow` This will destroy the window for the program.
-Over time, we will add more logic into this cleanup function. While its not completely necessary to cleanup properly, as the OS will delete everything for us anyway when the program terminates, its good practice to do it.
+Over time, we will add more logic into this cleanup function. While it's not completely necessary to cleanup properly, as the OS will delete everything for us anyway when the program terminates, it's good practice to do it.
 
 vk_engine.cpp, line 37
 ```cpp

--- a/docs/chapter-1/vulkan_init_code.md
+++ b/docs/chapter-1/vulkan_init_code.md
@@ -175,7 +175,7 @@ Once we have a VkPhysicalDevice, we can directly build a VkDevice from it.
 
 And at the end, we store the handles in the class.
 
-Thats it, we have initialized Vulkan. We can now start calling Vulkan commands.
+That's it, we have initialized Vulkan. We can now start calling Vulkan commands.
 
 But before we start executing commands, there is one last thing to do.
 

--- a/docs/chapter-1/vulkan_mainloop_code.md
+++ b/docs/chapter-1/vulkan_mainloop_code.md
@@ -89,7 +89,7 @@ Next, we are going to request an image index from the swapchain.
 	VK_CHECK(vkAcquireNextImageKHR(_device, _swapchain, 1000000000, _presentSemaphore, nullptr, &swapchainImageIndex));
 ```
 
-vkAcquireNextImageKHR will request the image index from the swapchain, and if the swapchain doesnt have any image we can use, it will block the thread with a maximum for the timeout set, which will be 1 second. This will be our FPS lock.
+vkAcquireNextImageKHR will request the image index from the swapchain, and if the swapchain doesn't have any image we can use, it will block the thread with a maximum for the timeout set, which will be 1 second. This will be our FPS lock.
 
 Check how we are sending the _presentSemaphore to it. This is to make sure that we can sync other operations with the swapchain having an image ready to render.
 

--- a/docs/chapter-1/vulkan_renderpass_code.md
+++ b/docs/chapter-1/vulkan_renderpass_code.md
@@ -72,8 +72,8 @@ void VulkanEngine::init_default_renderpass()
 	// we keep the attachment stored when the renderpass ends
 	color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 	//we don't care about stencil
-	color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;	
-	color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_don't_CARE;	
+	color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_don't_CARE;
 
 	//we don't know or care about the starting layout of the attachment
 	color_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -131,7 +131,7 @@ Now that the main attachment and the subpass is done, we can create the renderpa
 ```
 We will have only 1 attachment, which will be the color_attachment defined above, for our main color target. Then we also connect the subpass into it.
 
-Thats it, we have now created our very basic renderpass. We will go back to this code later when we add depth testing, which needs more attachments defined.
+That's it, we have now created our very basic renderpass. We will go back to this code later when we add depth testing, which needs more attachments defined.
 
 ## Framebuffers
 Once the renderpass is made, we can use it to create the framebuffers. Framebuffers are created from a given renderpass, and they act as link between the attachments of the renderpass and the real images that they should render to.

--- a/docs/chapter-1/vulkan_renderpass_code.md
+++ b/docs/chapter-1/vulkan_renderpass_code.md
@@ -72,8 +72,8 @@ void VulkanEngine::init_default_renderpass()
 	// we keep the attachment stored when the renderpass ends
 	color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 	//we don't care about stencil
-	color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_don't_CARE;	
-	color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_don't_CARE;
+	color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;	
+	color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
 	//we don't know or care about the starting layout of the attachment
 	color_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;

--- a/docs/chapter-2/pipeline_walkthrough.md
+++ b/docs/chapter-2/pipeline_walkthrough.md
@@ -166,7 +166,7 @@ VkPipelineMultisampleStateCreateInfo vkinit::multisampling_state_create_info()
 ```
 
 ### Color Blend Attachment State
-`VkPipelineColorBlendAttachmentState` Controls how this pipeline blends into a given attachment. We are rendering to only 1 attachment, so we will just need one of them, and defaulted to "not blend" and just override. In here it's possible to make objects that will blend with the image. This one also doesnt have sType + pNext
+`VkPipelineColorBlendAttachmentState` Controls how this pipeline blends into a given attachment. We are rendering to only 1 attachment, so we will just need one of them, and defaulted to "not blend" and just override. In here it's possible to make objects that will blend with the image. This one also doesn't have sType + pNext
 
 
 ```cpp

--- a/docs/chapter-2/triangle_walkthrough.md
+++ b/docs/chapter-2/triangle_walkthrough.md
@@ -42,7 +42,7 @@ void main()
 
 In our first vertex shader, we create a constant array of 3 vector-3s, which will be the positions for each of the vertices of the triangle. 
 
-We then have to write to `gl_Position` to tell the GPU what's the position for the vertex. This is obligatory for vertex shaders to work. In here we will access our positions array with gl_VertexIndex, which is the number of the vertex that this shader is being executed for. We then convert it into a vec4 because thats what `gl_Position` expects.
+We then have to write to `gl_Position` to tell the GPU what's the position for the vertex. This is obligatory for vertex shaders to work. In here we will access our positions array with gl_VertexIndex, which is the number of the vertex that this shader is being executed for. We then convert it into a vec4 because that's what `gl_Position` expects.
 
 ## Fragment shader
 
@@ -78,9 +78,9 @@ Check the project "Shaders" on the generated visual studio solution, and the new
 If you look at the CMakeLists.txt at the root project folder, you will see that it's creating a custom Shader targets building from grabbing all the files that end in *.frag and *.vert from the shaders/ folder. I recommend you read that section. It is commented explaining how it works.
 
 ## Vulkan Shader workflow
-Vulkan doesnt understand GLSL directly, it understands SPIRV. SPIRV is shader bytecode for Vulkan. Think of SPIRV as a binary optimized version of GLSL. 
+Vulkan doesn't understand GLSL directly, it understands SPIRV. SPIRV is shader bytecode for Vulkan. Think of SPIRV as a binary optimized version of GLSL. 
 
-We need to convert the GLSL we have just written into spirv, so that Vulkan can understand it. Thats what we did above, and the result is some .spv files that we can load onto Vulkan.
+We need to convert the GLSL we have just written into spirv, so that Vulkan can understand it. That's what we did above, and the result is some .spv files that we can load onto Vulkan.
 
 The Vulkan SDL comes with a built version of the glslang shader compiler, which is what we are using here to compile the shaders offline. It is possible to use the same compiler as a library, and compile GLSL shaders on-the-fly in your game engine, but we are not going to do that *yet*. 
 

--- a/docs/chapter-3/depth_buffer.md
+++ b/docs/chapter-3/depth_buffer.md
@@ -204,7 +204,7 @@ void VulkanEngine::init_default_renderpass()
     depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     depth_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    depth_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_don't_CARE;
+    depth_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     depth_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     depth_attachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 

--- a/docs/chapter-3/depth_buffer.md
+++ b/docs/chapter-3/depth_buffer.md
@@ -204,7 +204,7 @@ void VulkanEngine::init_default_renderpass()
     depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     depth_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    depth_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depth_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_don't_CARE;
     depth_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     depth_attachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
@@ -304,7 +304,7 @@ depthWriteEnable allows the depth to be written. While DepthTest and DepthWrite 
 The depthCompareOp holds the depth-testing function. Set to `VK_COMPARE_OP_ALLWAYS` to not do any depthtest at all. Other common depth compare OPs are `VK_COMPARE_OP_LESS` (Only draw if Z < whatever is on the depth buffer), or `VK_COMPARE_OP_EQUAL` (only draw if the depth z matches) 
 
 min and max depth bounds lets us cap the depth test. If the depth is outside of bounds, the pixel will be skipped.
-And last, we won't be using stencil test, so thats set to VK_FALSE by default.
+And last, we won't be using stencil test, so that's set to VK_FALSE by default.
 
 Now we go back to the PipelineBuilder, and we add the depth state to it.
 

--- a/docs/chapter-3/scene_management.md
+++ b/docs/chapter-3/scene_management.md
@@ -224,7 +224,7 @@ void VulkanEngine::draw_objects(VkCommandBuffer cmd,RenderObject* first, int cou
 	{
 		RenderObject& object = first[i];
 
-		//only bind the pipeline if it doesnt match with the already bound one
+		//only bind the pipeline if it doesn't match with the already bound one
 		if (object.material != lastMaterial) {
 
 			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, object.material->pipeline);

--- a/docs/chapter-3/triangle_mesh_code.md
+++ b/docs/chapter-3/triangle_mesh_code.md
@@ -397,7 +397,7 @@ void VulkanEngine::init_pipelines()
 }
 ```
 
-There is not much here, other than connecting the vertex input info to the pipeline builder. With that and adding the `tri_mesh.vert` vertex shader, thats all we need. We also make sure that each shader module is correctly deleted at the end of the function.
+There is not much here, other than connecting the vertex input info to the pipeline builder. With that and adding the `tri_mesh.vert` vertex shader, that's all we need. We also make sure that each shader module is correctly deleted at the end of the function.
 
 Now we are holding a `_meshPipeline` that knows how to render a colored mesh. Let's replace the inner loop of `draw()` function to use the new pipeline and draw the mesh. 
 

--- a/docs/chapter-4/descriptors_code.md
+++ b/docs/chapter-4/descriptors_code.md
@@ -349,7 +349,7 @@ We fill the struct, and then copy it to the buffer with the same pattern that we
 The buffer now holds the proper camera data, so now we can bind it.
 
 ```cpp
-//only bind the pipeline if it doesnt match with the already bound one
+//only bind the pipeline if it doesn't match with the already bound one
 if (object.material != lastMaterial) {
 
 	vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, object.material->pipeline);

--- a/docs/chapter-4/descriptors_code_more.md
+++ b/docs/chapter-4/descriptors_code_more.md
@@ -229,7 +229,7 @@ if (!load_shader_module("../../shaders/default_lit.frag.spv", &colorMeshShader))
 }
 ```
 
-If you try to run this now, it should work, but the color of the objects will be unknown, as we aren't writing to the buffers yet. Its probably zero initialized, which will mean the ambient light does nothing.
+If you try to run this now, it should work, but the color of the objects will be unknown, as we aren't writing to the buffers yet. it's probably zero initialized, which will mean the ambient light does nothing.
 
 Lets write into the buffer from our core render loop.
 On `draw_objects()` , before or after when we map the camera buffer and write to it.
@@ -302,7 +302,7 @@ That's it, now our descriptor is created as dynamic. Now, when binding the descr
 Lets go to `draw_objects()` function, and modify the place where the descriptor set is bound so that it uses the offsets.
 ```cpp
 
-//only bind the pipeline if it doesnt match with the already bound one
+//only bind the pipeline if it doesn't match with the already bound one
 if (object.material != lastMaterial) {
 
 vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, object.material->pipeline);

--- a/docs/chapter-4/double_buffering.md
+++ b/docs/chapter-4/double_buffering.md
@@ -12,7 +12,7 @@ It is possible to make the CPU render ahead more frames, which can be useful if 
 ## Object lifetime
 Most Vulkan objects are used while the GPU is performing its rendering work, so it is not possible to modify or delete them while they are in use.
 An example of this is command buffers. Once you submit a command buffer into a queue, that buffer can't be reset or modified until the GPU has finished executing its commands.
-You can control this using Fences. If you submit a command buffer that will signal a fence, and then you wait until that fence is signaled, you can be sure that the command buffer can now be reused or modified. Its the same for the other related objects used in those commands.
+You can control this using Fences. If you submit a command buffer that will signal a fence, and then you wait until that fence is signaled, you can be sure that the command buffer can now be reused or modified. it's the same for the other related objects used in those commands.
 
 
 ## The Frame struct

--- a/docs/chapter-4/storage_buffers.md
+++ b/docs/chapter-4/storage_buffers.md
@@ -41,7 +41,7 @@ void VulkanEngine::init_descriptors()
 }
 ```
 Shader Storage buffers are created in the same way as uniform buffers. They also work in mostly the same way, they just have different properties like increased maximum size, and being writeable in shaders.
-We are going to reserve an array of 10000 ObjectDatas per frame. This means that we can hold up to 10000 object matrices, rendering 10000 objects per frame. Its a small number, but at the moment it's not a problem. Unreal Engine grows their object buffer as needed when the engine loads more objects, but we don't have any growable buffer abstraction so we reserve upfront.
+We are going to reserve an array of 10000 ObjectDatas per frame. This means that we can hold up to 10000 object matrices, rendering 10000 objects per frame. it's a small number, but at the moment it's not a problem. Unreal Engine grows their object buffer as needed when the engine loads more objects, but we don't have any growable buffer abstraction so we reserve upfront.
 While the size here is 10000, you can increase it to whatever you want. The maximum sizes for storage buffers are quite big, in most GPUs they can be as big as the VRAM can fit, so you can do this with 100 million matrices if you want.
 
 We will now need to add it to the descriptor sets.

--- a/docs/chapter-5/drawing_images.md
+++ b/docs/chapter-5/drawing_images.md
@@ -164,7 +164,7 @@ void VulkanEngine::init_pipelines()
 }
 ```
 
-We can now add a new render object that will be the textured mesh. For that, im using lost_empire.obj, which is a minecraft map. This makes for a good test case to check textured rendering.
+We can now add a new render object that will be the textured mesh. For that, I'm using lost_empire.obj, which is a minecraft map. This makes for a good test case to check textured rendering.
 
 ```cpp
 void VulkanEngine::load_meshes()

--- a/docs/chapter-5/loading_images.md
+++ b/docs/chapter-5/loading_images.md
@@ -53,7 +53,7 @@ bool vkutil::load_image_from_file(VulkanEngine& engine, const char* file, Alloca
 }
 ```
 
-At the start, we use `stbi_load()` to load a texure directly from file into a CPU array of pixels. The function will return nullptr if it doesnt find the file, or if there are errors.
+At the start, we use `stbi_load()` to load a texure directly from file into a CPU array of pixels. The function will return nullptr if it doesn't find the file, or if there are errors.
 When loading the function, we also send `STBI_rgb_alpha` to the function, which will make the library always load the pixels as RGBA 4 channels. This is useful as it will match with the format we will use for Vulkan.
 
 With the texture file loaded into the pixels array, we can create a staging buffer and store the pixels there. This is almost the same as what we did in the last article when copying meshes to the GPU.

--- a/docs/chapter-5/memory_transfers.md
+++ b/docs/chapter-5/memory_transfers.md
@@ -15,7 +15,7 @@ Because this is necessary when dealing with textures, we will implement this cop
 This will likely cause an immediate rendering speed-up if you have been trying to load heavy meshes.
 
 ## Upload Context
-As copying meshes from CPU buffer to GPU buffer wont be the only thing we are going to do, we are going to create a small abstraction for this sort of short-lived commands. 
+As copying meshes from CPU buffer to GPU buffer won't be the only thing we are going to do, we are going to create a small abstraction for this sort of short-lived commands. 
 
 Let's begin by adding a new struct to VulkanEngine, and a function for immediate command execution.
 
@@ -52,7 +52,7 @@ In `init_sync_structures()`, we will initialize the fence alongside the renderin
 	});
 ```
 
-On this fence we wont set the `VK_FENCE_CREATE_SIGNALED_BIT` flag, as we will not try to wait on it before sending commands like we do in the render loop.
+On this fence we won't set the `VK_FENCE_CREATE_SIGNALED_BIT` flag, as we will not try to wait on it before sending commands like we do in the render loop.
 
 The other thing is the command pool, which we create in `init_commands`
 
@@ -144,7 +144,7 @@ void VulkanEngine::upload_mesh(Mesh& mesh)
 }
 ```
 
-We are creating the stagingBuffer with enough size to hold the mesh data, and giving it the `VK_BUFFER_USAGE_TRANSFER_SRC_BIT` usage flag. This flag tells Vulkan that this buffer will only be used as source for transfer commands. We wont be using the staging buffer for rendering.
+We are creating the stagingBuffer with enough size to hold the mesh data, and giving it the `VK_BUFFER_USAGE_TRANSFER_SRC_BIT` usage flag. This flag tells Vulkan that this buffer will only be used as source for transfer commands. We won't be using the staging buffer for rendering.
 
 We can now copy the mesh data to this buffer
 

--- a/docs/extra-chapter/abstracting_descriptors.md
+++ b/docs/extra-chapter/abstracting_descriptors.md
@@ -7,7 +7,7 @@ nav_order: 33
 
 Creating and managing descriptor sets is one of the most painful things about vulkan. Creating an abstraction that simplifies is is really important, and will improve the workflow a lot.
 
-Im going to show you a simple way to create a thin abstraction over descriptor sets, that makes it easier to handle them.
+I'm going to show you a simple way to create a thin abstraction over descriptor sets, that makes it easier to handle them.
 
 The end result will look like this.
 
@@ -40,9 +40,9 @@ The abstraction is composed of 3 modular parts.
 * DescriptorLayoutCache: caches DescriptorSetLayouts to avoid creating duplicated layouts.
 * DescriptorBuilder: Uses the 2 objects above to allocate and write a descriptor set and its layout automatically.
 
-Note that both the layout and the allocator wont be threadsafe, but they could be made so relatively easily. The descriptor builder is fully stateless so it would be threadsafe by default.
+Note that both the layout and the allocator won't be threadsafe, but they could be made so relatively easily. The descriptor builder is fully stateless so it would be threadsafe by default.
 
-We are going to put the 3 classes into `vk_descriptors.h` and `vk_descriptors.cpp`. They wont depend on the rest of the engine, only on vulkan.h and STL.
+We are going to put the 3 classes into `vk_descriptors.h` and `vk_descriptors.cpp`. They won't depend on the rest of the engine, only on vulkan.h and STL.
 
 ## Descriptor Allocator
 Explained in chapter 4, descriptors have to be allocated from a pool. You need to manage this pool, and create more as needed, also reusing them whenever possible if you allocate descriptors every frame.
@@ -51,7 +51,7 @@ We are going to make a basic abstraction where it allocates pools of 1000 descri
 
 We will have multiple allocators in the engine. One of them will be for "persistent" descriptors, and one allocator per frame to use for dynamically allocated descriptors.
 
-Lets start with the class itself
+Let's start with the class itself
 
 ```cpp
 class DescriptorAllocator {
@@ -92,7 +92,7 @@ class DescriptorAllocator {
 	};
 ```
 
-We will store multipliers of descriptor types in the PoolSizes struct. The idea is that its a multiplier on the number of descriptor sets allocated for the pools.
+We will store multipliers of descriptor types in the PoolSizes struct. The idea is that it's a multiplier on the number of descriptor sets allocated for the pools.
 
 For example, if you set `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER` to `4.f` in there, it means that when a pool for 1000 descriptors is allocated, the pool will have space for 4000 combined image descriptors. The numbers in there as default are a reasonable default, but you can improve memory usage of this allocator significantly if you tweak it to what your project uses. 
 
@@ -174,14 +174,14 @@ VkDescriptorPool DescriptorAllocator::grab_pool()
 }
 ```
 
-On the function, we reuse a descriptor pool if its availible, and if we dont have one, we then create a new pool to hold 1000 descriptors. The 1000 count is arbitrary. Could also create growing pools or different sizes.
+On the function, we reuse a descriptor pool if it's availible, and if we don't have one, we then create a new pool to hold 1000 descriptors. The 1000 count is arbitrary. Could also create growing pools or different sizes.
 
 With those functions coded, we can now focus on the main `allocate` function, which is where the meat of the allocator is.
 
 ```cpp
 bool DescriptorAllocator::allocate(VkDescriptorSet* set, VkDescriptorSetLayout layout)
 	{
-		//initialize the currentPool handle if its null
+		//initialize the currentPool handle if it's null
 		if (currentPool == VK_NULL_HANDLE){
 
 			currentPool = grab_pool();
@@ -231,7 +231,7 @@ bool DescriptorAllocator::allocate(VkDescriptorSet* set, VkDescriptorSetLayout l
 	}
 ```
 
-In the function, we begin by initializing the `currentPool` handle if its null, and reusing or allocating a new descriptor pool.
+In the function, we begin by initializing the `currentPool` handle if it's null, and reusing or allocating a new descriptor pool.
 
 After that, we try to allocate the descriptor using `vkAllocateDescriptorSets()`. After that call, we check the error code.
 If there is no error `VK_SUCCESS`, everything went fine and we can return from the function.
@@ -258,7 +258,7 @@ void DescriptorAllocator::reset_pools(){
 
 On the reset, we call `vkResetDescriptorPool` on every pool, and then move them to the `freePools` array for reuse. We also set the currentPool handle to null so that the allocation function tries to grab a pool on the next allocation.
 
-This simple allocator wont be the most optimal, but if you use it right by setting the proper size multipliers, it will be optimal.
+This simple allocator won't be the most optimal, but if you use it right by setting the proper size multipliers, it will be optimal.
 If you have common descriptor set shapes, it might be a good idea to have an allocator just for those descriptors. For example an allocator only for sets that hold textures.
 
 
@@ -387,7 +387,7 @@ To use `std::sort` we need to include `<algorithm>`. std::sort uses `operator<` 
 
 With it sorted, we can now try to find it in the hashmap. If we find it, we return the already created layout. If we cant find it, we create a new layout, add it to the cache, and then return it.
 
-The hashmap doesnt work without the operators, so now we implement them.
+The hashmap doesn't work without the operators, so now we implement them.
 For equality, we are going to do this
 ```cpp
 bool DescriptorLayoutCache::DescriptorLayoutInfo::operator==(const DescriptorLayoutInfo& other) const{
@@ -415,7 +415,7 @@ bool DescriptorLayoutCache::DescriptorLayoutInfo::operator==(const DescriptorLay
 }
 ```
 
-We first compare if the bindings vector is the same size, and if it is, we compare each of the bindings in there. This is why we need to have them sorted, so testing equality doesnt require a more complex loop.
+We first compare if the bindings vector is the same size, and if it is, we compare each of the bindings in there. This is why we need to have them sorted, so testing equality doesn't require a more complex loop.
 
 The hash looks like this.
 
@@ -428,7 +428,7 @@ size_t DescriptorLayoutCache::DescriptorLayoutInfo::hash() const{
 
 		for (const VkDescriptorSetLayoutBinding& b : bindings)
 		{
-			//pack the binding data into a single int64. Not fully correct but its ok
+			//pack the binding data into a single int64. Not fully correct but it's ok
 			size_t binding_hash = b.binding | b.descriptorType << 8 | b.descriptorCount << 16 | b.stageFlags << 24;
 
 			//shuffle the packed binding data and xor it with the main hash
@@ -439,7 +439,7 @@ size_t DescriptorLayoutCache::DescriptorLayoutInfo::hash() const{
 	}
 ```
 
-We will begin the hash by hashing the number of bindings that we have in the layout info. After that, we compress the data of each binding into a size_t, and xor that one with the hash. While the packing we do is not really the best, it doesnt matter that much.
+We will begin the hash by hashing the number of bindings that we have in the layout info. After that, we compress the data of each binding into a size_t, and xor that one with the hash. While the packing we do is not really the best, it doesn't matter that much.
 
 The descriptor cache is now live. You can use similar code to cache almost any other vulkan object. Some recomended ones are pipelines themselves and render passes.
 
@@ -471,13 +471,13 @@ private:
 	};
 ```
 
-On the `begin()` function we request an allocator and a layout cache. This builder can be used without them, but it works much better when its all together.
+On the `begin()` function we request an allocator and a layout cache. This builder can be used without them, but it works much better when it's all together.
 
-Next we have the bind functions, one for buffers, and other for images. They are very similar.
+Next we have the bind functions, one for buffers, and another for images. They are very similar.
 
-And last, 2 build functions. One that returns layout, and other that doesnt. You dont allways need the layout to its nice to not have it in the call.
+And last, 2 build functions. One that returns layout, and another that doesn't. You don't always need the layout, so it's nice to not have it in the call.
 
-The data in the class will be the cache and allocator that we store, alongside 2 vectors. One for descriptor writes, and other for layout bindings. We will use those to create the cache and write the descriptor data.
+The data in the class will be the cache and allocator that we store, alongside 2 vectors. One for descriptor writes, and another for layout bindings. We will use those to create the cache and write the descriptor data.
 
 Lets start with the begin call.
 ```cpp
@@ -559,9 +559,9 @@ We begin by filling in the layoutInfo and creating the layout. Because we have b
 
 With the layout created, we can use the descriptor allocator to allocate a new descriptor set.
 
-Then we can write into it. We need to go through the array of writes, and make sure that they point to the newly created descriptor set. Once thats done, we can finally call `vkUpdateDescriptorSets` with that array, setting the data in the set.
+Then we can write into it. We need to go through the array of writes, and make sure that they point to the newly created descriptor set. Once that's done, we can finally call `vkUpdateDescriptorSets` with that array, setting the data in the set.
 
-Thats it, now you have a thin abstraction over descriptor sets and their layouts, that makes it much easier to handle them at runtime.
+That's it, now you have a thin abstraction over descriptor sets and their layouts, that makes it much easier to handle them at runtime.
 You can look at how the code in the engine uses it.
 
 The `draw_objects()` function in the engine branch uses this abstractions, so you can check how they are used. https://github.com/vblanco20-1/vulkan-guide/blob/engine/extra-engine/vk_engine.cpp

--- a/docs/extra-chapter/asset_system.md
+++ b/docs/extra-chapter/asset_system.md
@@ -6,7 +6,7 @@ nav_order: 31
 ---
 In the tutorial, we have been loading .obj and .png files directly. The issue with doing that is that we depend on 3rd party libraries (stb_image and tinyobj), and loading the formats like that is quite inefficient. You have probably seen that the engine takes a couple seconds to load when you are in debug mode.
 
-On real engines, you dont load those formats at runtime. Instead, you convert those formats into a engine-specific fast-loadable format, and then load that.
+On real engines, you don't load those formats at runtime. Instead, you convert those formats into a engine-specific fast-loadable format, and then load that.
 
 The advantages are considerable:
 * Orders of magnitude faster loading.
@@ -19,9 +19,9 @@ The advantages are considerable:
 On the other side, there are a few disadvantages to take into account.
 * Need to develop and maintain the custom formats.
 * Need to develop and maintain a converter that converts from classic formats into the custom one.
-* Custom formats wont be readable by any tool.
+* Custom formats won't be readable by any tool.
 
-In general, its a good idea to implement an asset system into your engine, unless you dont care about the load times or the executable bloat. While maintaining the custom formats is extra work, its not that much compared to the productivity increase of having an engine that loads scenes very quickly.
+In general, it's a good idea to implement an asset system into your engine, unless you don't care about the load times or the executable bloat. While maintaining the custom formats is extra work, it's not that much compared to the productivity increase of having an engine that loads scenes very quickly.
 
 # Asset System architecture
 
@@ -37,7 +37,7 @@ Engine and Converter will both link AssetLib. Converter will link all the differ
 
 
 # Libraries
-We will add 2 libraries to the project. The first one is LZ4 compression library, which we will be using to compress the binary blobs. The second one is nhlomans Json library, which is the easiest to use json library for modern Cpp and its really nice to use.
+We will add 2 libraries to the project. The first one is LZ4 compression library, which we will be using to compress the binary blobs. The second one is nhlomans Json library, which is the easiest to use json library for modern Cpp and it's really nice to use.
 
 * LZ4: https://github.com/lz4/lz4
 * Json: https://github.com/nlohmann/json
@@ -48,7 +48,7 @@ We are going to keep the file format very simple, while still being very fast to
 We are taking a hint from how the glTF format works, and have a binary file that holds a json header alongside a binary blob.
 The json header will contain metadata and information about the object, and the binary blob will contain the raw data of the object, like the pixels of a texture.
 
-For the binary blob, we will also compress it using LZ4 format. LZ4 is a compression codec that is optimized around speed, and if we use it, its very likely that we will go faster than reading uncompressed data from disk. But we will also keep space in the format for other compression systems, as things like the new consoles have .zip or kraken compression implemented in hardware.
+For the binary blob, we will also compress it using LZ4 format. LZ4 is a compression codec that is optimized around speed, and if we use it, it's very likely that we will go faster than reading uncompressed data from disk. But we will also keep space in the format for other compression systems, as things like the new consoles have .zip or kraken compression implemented in hardware.
 
 All assets will follow the format of json metadata + compressed binary blob. This way the code will be unified and easier to handle.
 
@@ -124,7 +124,7 @@ We will be doing purely binary files.
 
 We begin by storing the 4 chars that are the asset type. For textures this will be `TEXI`, and for meshes it will be `MESH`. We can use this to easily identify if the binary file we are loading is a mesh or a texture, or some wrong format.
 
-Next, we store Version, which is a single uint32 number. We can use this if we change the format at some point, to give an error when trying to load it. Its critical to allways version your file formats.
+Next, we store Version, which is a single uint32 number. We can use this if we change the format at some point, to give an error when trying to load it. It's critical to allways version your file formats.
 
 After the version, we store the lenght, in bytes, of the json string, and then the lenght of the binary blob.
 
@@ -169,7 +169,7 @@ Then we read the json string by using the lenght stored in the header, and same 
 
 We are not doing any version or type check yet here. The functions will just return false if the file isnt found, but there is no error checking.
 
-Thats all we needed for the asset file itself. Its just a very simple dump of the json string and the binary drop into a packed file.
+That's all we needed for the asset file itself. It's just a very simple dump of the json string and the binary drop into a packed file.
 
 The more interesting thing is handling textures and meshes. We will only walkthrough the Texture save/load logic, as meshes work in the same way, you can look at the codebase to see the differences.
 
@@ -204,7 +204,7 @@ namespace assets {
 Like with the main asset file, we are going to keep the API very small and stateless.
 The `read_texture_info` will parse the metadata json in a file and convert it into the TextureInfo struct, which is the main data of the texture. 
 
-`unpack_texture` will work with a texture info alongside the binary blob of pixel data, and will decompress the texture into the destination buffer. Its very important that the destination buffer is big enough, or it will overflow. This is meant to be used to unpack the blob directly into a buffer.
+`unpack_texture` will work with a texture info alongside the binary blob of pixel data, and will decompress the texture into the destination buffer. It's very important that the destination buffer is big enough, or it will overflow. This is meant to be used to unpack the blob directly into a buffer.
 
 ```cpp
 	//prepare asset file and texture info
@@ -324,7 +324,7 @@ void assets::unpack_texture(TextureInfo* info, const char* sourcebuffer, size_t 
 
 When unpacking, we just decompress directly into the target destination. If the file isnt compressed, we then just memcpy directly.
 
-Thats all for the texture asset logic. For the mesh logic, it works in a similar way, so you can look at the code.
+That's all for the texture asset logic. For the mesh logic, it works in a similar way, so you can look at the code.
 
 * Core asset system: https://github.com/vblanco20-1/vulkan-guide/blob/engine/assetlib/asset_loader.cpp
 * Texture loader: https://github.com/vblanco20-1/vulkan-guide/blob/engine/assetlib/texture_asset.cpp
@@ -334,7 +334,7 @@ Thats all for the texture asset logic. For the mesh logic, it works in a similar
 ## Converter
 
 With the texture save/load logic implemented, we can now look at the converter itself.
-The converter will be a separate executable from the normal engine. This is to isolate all of the libs it will use so that they dont pollute the engine. This also means we can compile it in release mode and have it convert everything very fast, and then we load that from our debug mode engine.
+The converter will be a separate executable from the normal engine. This is to isolate all of the libs it will use so that they don't pollute the engine. This also means we can compile it in release mode and have it convert everything very fast, and then we load that from our debug mode engine.
 
 The entire codebase for the converted is here https://github.com/vblanco20-1/vulkan-guide/blob/engine/asset-baker/asset_main.cpp
 
@@ -372,7 +372,7 @@ for (auto& p : fs::directory_iterator(directory))
 We are using the Cpp17 Filesystem library. This is so we get an easy way of iterate a folder contents. If you cant use Cpp17 then you will have to use a platform API for that.
 
 We begin by storing argv[1] into a filesystem::path. We will then iterate the contents at that path using `directory_iterator`.
-For each file in the folder, we check if the extension is `.png`, and convert it as a texture. We convert into a mesh if its a `.obj` file.
+For each file in the folder, we check if the extension is `.png`, and convert it as a texture. We convert into a mesh if it's a `.obj` file.
 Textures will be stored as `.tx`, and meshes as `.mesh`.
 
 The code inside the conversion function is copypasted from the code we used to have in the main engine. It works exactly the same, except instead of loading it into a buffer for the gpu, we use the asset library to store it to disk. We will be looking at the texture one, as again, the mesh is similar and you can look at the implementation.

--- a/docs/extra-chapter/cvar_system.md
+++ b/docs/extra-chapter/cvar_system.md
@@ -9,10 +9,10 @@ As the engine grows, we find that we have more and more configuration options in
 
 If you look at how engines like Unreal Engine or IDTech engines do it, they have a Console Variable system. Users can declare any console variable (CVAR) they want, and then access it through the code. Having the configuration and debug options all inside the same centralized location gives some very nice properties, such as having 1 centralized way to edit them, and being able to easily save them to disk.
 
-For the vulkan engine, we are going to implement a system for CVARs very similar to the one in Unreal Engine, but highly simplified. This is also something that can be done for any Cpp project, it doesnt require anything from the rest of the engine. The CVar system explained here is the same as the one that was created for the Novus Core project, but with some small tweaks.
+For the vulkan engine, we are going to implement a system for CVARs very similar to the one in Unreal Engine, but highly simplified. This is also something that can be done for any Cpp project, it doesn't require anything from the rest of the engine. The CVar system explained here is the same as the one that was created for the Novus Core project, but with some small tweaks.
 
 ## Usage
-To declare a CVAR, its done this way:
+To declare a CVAR, it's done this way:
 ```cpp
 
 //checkbox CVAR
@@ -43,7 +43,7 @@ Using the cvar property is the quickest and most efficient way to access a CVAR,
 
 ```cpp
 
-//returns a pointer because it will be nullptr if the cvar doesnt exist
+//returns a pointer because it will be nullptr if the cvar doesn't exist
 int* value = CVarSystem::Get()->GetIntCvar("test.int");
 if(value)
 {
@@ -51,14 +51,14 @@ if(value)
 }
 
 //for the setter it can be done directly.
-//if the cvar doesnt exist, this does nothing
+//if the cvar doesn't exist, this does nothing
  CVarSystem::Get()->SetIntCvar("test.int",3);
 
 ```
 
-This makes CVars a sort of global database. Do not use it like that. CVars are meant for configuration variables and other similar globals, so its best to avoid using it as a global variable storage.
+This makes CVars a sort of global database. Do not use it like that. CVars are meant for configuration variables and other similar globals, so it's best to avoid using it as a global variable storage.
 
-Lastly, its possible to create cvars at runtime. Most useful if you are loading cvars from files or as part of a modding system or scripts.
+Lastly, it's possible to create cvars at runtime. Most useful if you are loading cvars from files or as part of a modding system or scripts.
 The AutoCvar things above use this
 
 ```cpp
@@ -67,7 +67,7 @@ CVarParameter* cvar =  CVarSystem::Get()->CreateIntCVar("test.int2", "another in
 
 ```
 
-Its not possible to remove cvars. This is by design, as it doesnt make a lot of sense to delete these global variables.
+It's not possible to remove cvars. This is by design, as it doesn't make a lot of sense to delete these global variables.
 
 All cvars will get a spot into the cvar editor menu on the Imgui menu bar. This makes it very easy to see what the cvar values are and allows a centralized spot to edit them from inside the engine.
 
@@ -110,7 +110,7 @@ CVarSystem* CVarSystem::Get()
 ```
 
 The Impl class is empty for now, but we implement the `CVarSystem::Get()` function. In there, we declare a static CVarSystemImpl object, and return its adress.
-This is known as the statically initialized singleton, and its the modern way of doing Singletons in Cpp11 and more. It has the very interesting property that Get() is fully threadsafe due to the rules of static variables inside functions.
+This is known as the statically initialized singleton, and it's the modern way of doing Singletons in Cpp11 and more. It has the very interesting property that Get() is fully threadsafe due to the rules of static variables inside functions.
 
 To store the cvars, we are going to implement a way to store the cvars into the System, for that we start by implementing a very simple cvar struct
 
@@ -212,11 +212,11 @@ struct CVarArray
 };
 ```
 
-We will be using templates for this to make sure its much simpler to implement the multiple types of cvars.
+We will be using templates for this to make sure it's much simpler to implement the multiple types of cvars.
 
 Starting by the `CVarStorage<T>` type, where we store the current and initial values of a given CVar, alongside the pointer to the `CVarParamter` this Storage holds the value for.
 
-`CVarArray<T>` is an array of those CVarStorage objects, with a few functions to handle said array. Its going to be a very typical heap-allocated array like a vector, but we wont support resizing.
+`CVarArray<T>` is an array of those CVarStorage objects, with a few functions to handle said array. It's going to be a very typical heap-allocated array like a vector, but we won't support resizing.
 
 On the array, we hold an integer to know how filled it is, and we use the index to get the data. This index will correlate to the index stored in a CVarStorage. 
 
@@ -238,7 +238,7 @@ public:
 	CVarArray<std::string> stringCVars{ MAX_STRING_CVARS };
 
 	//using templates with specializations to get the cvar arrays for each type.
-	//if you try to use a type that doesnt have specialization, it will trigger a linked error
+	//if you try to use a type that doesn't have specialization, it will trigger a linked error
 	template<typename T>
 	CVarArray<T>* GetCVarArray();
 
@@ -260,10 +260,10 @@ public:
 }
 ```
 
-We are going to hardcode the array sizes for all the cvars. This is done to simplify the system. Generally you dont really have that many cvars, so its not really wasting much space. 1000 float and int cvars is bigger than what UnrealEngine uses, and Quake 3 only had a few dozens.
+We are going to hardcode the array sizes for all the cvars. This is done to simplify the system. Generally you don't really have that many cvars, so it's not really wasting much space. 1000 float and int cvars is bigger than what UnrealEngine uses, and Quake 3 only had a few dozens.
 
 One thing to note here is the `GetCVarArray` template trick. By doing this, we can allow a very significant code repetition when dealing with the different data arrays.
-We start by declaring the GetCVarArray template function, with a empty implementation that will error, in case its not implemented. We then follow with 3 separated specializations of the GetCVarArray template.
+We start by declaring the GetCVarArray template function, with a empty implementation that will error, in case it's not implemented. We then follow with 3 separated specializations of the GetCVarArray template.
 The end result of this is that we can then do this.
 
 ```cpp
@@ -352,7 +352,7 @@ CVarParameter* CVarSystemImpl::CreateFloatCVar(const char* name, const char* des
 On the typed CreateFloatCVar function, we initialize the cvar with the above function, and then we use 
 `GetCVarArray<double>()` to grab the correct data array to insert the cvar into. We also make sure to set the param->type of the cvar to Float type.
 
-For int and string its the same just replacing the types. 
+For int and string it's the same just replacing the types. 
 
 Now that we can create cvars, lets continue on the GetCVar function
 ```cpp
@@ -505,4 +505,4 @@ Again, this works exactly the same for all other types.
 
 If you want to add more types to the cvar system, you just need to create the functions in the public API, implement them, and add a storage array to the implementation. Some common types to add are vector properties, or maybe even other objects.
 
-For the imgui editor itself. Its just normal imgui edit functions that are used from the data arrays.
+For the imgui editor itself. It's just normal imgui edit functions that are used from the data arrays.

--- a/docs/extra-chapter/extra-chapter.md
+++ b/docs/extra-chapter/extra-chapter.md
@@ -7,5 +7,5 @@ permalink: /docs/extra_chapter
 ---
 
 # Extra chapter
-In this chapter, there are general articles that don't fit in the main track. All here is optional, and can be of interest even if its outside of the tutorial.
+In this chapter, there are general articles that don't fit in the main track. All here is optional, and can be of interest even if it's outside of the tutorial.
 {: .fs-6 .fw-300 }

--- a/docs/extra-chapter/implementing_imgui.md
+++ b/docs/extra-chapter/implementing_imgui.md
@@ -10,7 +10,7 @@ https://github.com/ocornut/imgui
 Dear Imgui is one of the best debug user interface libraries around. Using it makes it very easy to create debug windows with widgets of various kinds.
 This guide will use a few things from chapter 5 code, but can be done standalone just fine.
 
-Imgui itself is a portable library, but it doesnt do any user interaction or rendering by itself, you need to hook it into your renderer or input system. The library comes with a set of example implementations that hook those into imgui.
+Imgui itself is a portable library, but it doesn't do any user interaction or rendering by itself, you need to hook it into your renderer or input system. The library comes with a set of example implementations that hook those into imgui.
 We are using Vulkan for rendering, and SDL for user input events. Those 2 are covered by the example implementations, so we are going to use those.
 
 ## Compiling
@@ -43,7 +43,7 @@ For that, create a `init_imgui()` function, and make sure to call it as part of 
 void VulkanEngine::init_imgui()
 {
 	//1: create descriptor pool for IMGUI
-	// the size of the pool is very oversize, but its copied from imgui demo itself.
+	// the size of the pool is very oversize, but it's copied from imgui demo itself.
 	VkDescriptorPoolSize pool_sizes[] =
 	{
 		{ VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
@@ -108,7 +108,7 @@ void VulkanEngine::init_imgui()
 
 ```
 
-We begin by creating a descriptor pool that imgui needs. Having a descriptor pool just for imgui is the easiest. While this descriptor pool with 1000 of everything is likely going to be oversized, it wont really matter. 
+We begin by creating a descriptor pool that imgui needs. Having a descriptor pool just for imgui is the easiest. While this descriptor pool with 1000 of everything is likely going to be oversized, it won't really matter. 
 
 Then, we need to call the functions that initialize imgui itself, and the implementations for vulkan and for SDL
 On the Vulkan implementation, there are a few things that we have to hook. `VkInstance`, `VkPhysicalDevice`, `VkDevice`,the  `VkQueue` for graphics, and the descriptor pool we just created. Image count is for the overlapping of the commands. Use the same variables that you use when creating your swapchain.
@@ -152,9 +152,9 @@ Last thing is to render the imgui objects.
 On the `draw()` function, we call `ImGui::Render();` at the start. 
 
 As part of your main renderpass, call `ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);` right before you end it. 
-This will make imgui render as part as your main pass. If you have an UI pass of some kind, thats a good place to put it.
+This will make imgui render as part as your main pass. If you have an UI pass of some kind, that's a good place to put it.
 
-Thats really all that was needed, so enjoy using imgui!
+That's really all that was needed, so enjoy using imgui!
 
 ![map]({{site.baseurl}}/diagrams/IMGUI.png)
 

--- a/docs/extra-chapter/multithreading.md
+++ b/docs/extra-chapter/multithreading.md
@@ -11,7 +11,7 @@ For the last 20 years, computers and game consoles have had multiple cores in th
 
 A multicore CPU generally has multiple "standalone" cores, each of them being a full CPU on its own. Each of the cores can execute an arbitrary program on its own. If the CPU has hyperthreading/SMT, the CPU will not execute one thread of program instructions, but multiple (often 2). When this happens the inner resources of the CPU (memory units, math units, logic units, caches) will be shared between those multiple threads.
 
-The different cores on the CPU work on their own, and the CPU synchronizes the memory writes from one core so that other cores can also see it if it detects that one core is writing to the same memory location a different core is also writing into or reading from. That synchronization has a cost, so whenever you program multithreaded programs, its important to try to avoid having multiple threads writing to the same memory, or one thread writing and other reading.
+The different cores on the CPU work on their own, and the CPU synchronizes the memory writes from one core so that other cores can also see it if it detects that one core is writing to the same memory location a different core is also writing into or reading from. That synchronization has a cost, so whenever you program multithreaded programs, it's important to try to avoid having multiple threads writing to the same memory, or one thread writing and other reading.
 
 For correct synchronization of operations, CPUs also have specific instructions that can synchronize multiple cores, like atomic instructions. Those instructions are the backbone of the synchronization primitives that are used to communicate between threads.
 
@@ -35,7 +35,7 @@ Unreal Engine 4 will have a Game Thread and a Render Thread as main, and then a 
 
 While this approach is very popular and very easy to use, it has the drawback of scaling terribly. You will commonly see that Unreal Engine games struggle scaling past 4 cores, and in consoles the performance is much lower that it could be due to not filling the 8 cores with work. Another issue with this model is that if you have one of the threads have more work than the others, then the entire simulation will wait. In unreal engine 4, the Game Thread and Render Thread are synced at each frame, so if either of them is slow, both will be slowed as the run at the same time. A game that has lots of blueprint usage and AI calculations in UE4 will have the Game Thread busy doing work in 1 core, and then every other core in the machine unused.
 
-A common approach of enhancing this architecture is to move it more into a fork/join approach, where you have a main execution thread, and at some points, parts of the work is split between threads. Unreal Engine does this for animation and physics. While the Game Thread is the one in charge of the whole game logic part of the engine, when it reaches the point where it has to do animations, it will split the animations to calculate into small tasks, and distribute those across helper threads in other cores. This way while it still has a main timeline of execution, there are points where it gets extra help from the unused cores. This improves scalability, but its still not good enough as the rest of the frame is still singlethreaded.
+A common approach of enhancing this architecture is to move it more into a fork/join approach, where you have a main execution thread, and at some points, parts of the work is split between threads. Unreal Engine does this for animation and physics. While the Game Thread is the one in charge of the whole game logic part of the engine, when it reaches the point where it has to do animations, it will split the animations to calculate into small tasks, and distribute those across helper threads in other cores. This way while it still has a main timeline of execution, there are points where it gets extra help from the unused cores. This improves scalability, but it's still not good enough as the rest of the frame is still singlethreaded.
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;" data-mxgraph="{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;lightbox&quot;:false,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;xml&quot;:&quot;&lt;mxfile host=\&quot;app.diagrams.net\&quot; modified=\&quot;2021-01-10T15:48:25.695Z\&quot; agent=\&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36\&quot; etag=\&quot;D93s046FuunqymOw8Eon\&quot; version=\&quot;14.1.9\&quot; type=\&quot;device\&quot;&gt;&lt;diagram id=\&quot;ilJUOgdIxLSSPok9l4Cx\&quot; name=\&quot;Page-1\&quot;&gt;7ZpdU6MwFIZ/DZe7A+H7UtG6XuyOs9Vx3buUhMIIpIZg2/31m9DQQoPTqpTWdYszwskXfd6T5JyoZgbZ4orCWfydIJxqQEcLzbzQADAsADTxo6PlyuI60jClCZKVNoZx8gdLoy6tZYJw0arICElZMmsbQ5LnOGQtG6SUzNvVIpK2R53BKVYM4xCmqvU+QSxeWT3gbuzfcDKN65ENx1+VZLCuLL9JEUNE5g2TeamZASWEre6yRYBTAa/msmo3eqF0/WIU52yfBqOIPTz8+h1fPmU3FxSyu8BefpG9PMO0lF9YA07K+zuPCO9WcE0JrUqcp1K86rkGTOSLq2lypuL3Fcwwb3MbUwxR3RF/o1VfqzoSBlvWhBleCHvMspQbDH5bMEoecSBHzkmOxfskabplgmkyzfljyAlgbj9/xpQlXLszWZAlCIlhzudxwvB4BkMx5px7KrdRUuYICzj6+rVEB3jxImBjLRv3d0wyzOiSV5ENgC6Vlq4OXPk83ziOJU1xw2dqB4HSVafrnjdq8hsp6CvEBYq4N6RqdZ3PSqYI0QbShayhUVMO7hFRFIEwVLQTvuJMHNvpibC/Rdix9yJsHoqwqRC+myHIxCQ4u+4XsBfibsATz7bsnlzYNE8MsKUAPssTvrQmJO8VL7Kxh6wuvB6YmE5P/mu6u/G6Q+K11RUiXhZJWPQKFxscr9sF13dcE/YE17JOzHcdBe5PzBnSxg55kluh2K0bGgUjcR1mizTBkbdIt0MjiJaVLLQMWUlxv3MhssXVNRec6sNLphSiBLc0mFTXYTZR01DniTPkPPEUDYJStFqFjxP6YuT4voAlRMDrDFhcf6Lr3TpEEbT1vvZae7cOg65XvqLDiNA5pHyd0m9g0fM82B3PdPDHkEeTfW3Ge8wDb0j+dcrbitcLFi3eB74Do+8i3XWPFQVZ7ok5vvG2LFivPmoWPH74Eeyb/L5uCh1wY7bfFjy5/qE0UZPX95xM3BP6WEVexv9jCUONuewhYy5DzZp7kRZ8emmNjhOnYaVVE0pxDqLfwuJx6PChjxBhK6U0HJWvOehOpeaU4jzkEIQHigWMUyOsZoQfnDDYWv71YxNW872PTXg7kTg+YTWTkxk1zASwfFLM/sF8evtwtUMGMKQM9WCfW4auFX3Q7A6omcTmHLb3uOQEjvfsndPAslX+wP1qv1oB/rj5A3ZV1vg3APPyLw==&lt;/diagram&gt;&lt;/mxfile&gt;&quot;}"></div>
 <script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js"></script>
@@ -121,7 +121,7 @@ void PerformGameLogic(){
 
 In our main game loop, we have a sequence of things that we require to do for each gameplay frame. We need to query input, update AIs, animate objects... . All of this is a lot of work, so we need to find something that is a "standalone" task that we can safely ship to other threads. After looking into the codebase, we find that UpdateAnimation() on each AiCharacter is something that only accesses that character, and as such is safe if we ship it to multiple threads.
 
-There is something we can use here that will work great, known as a ParallelFor. ParallelFor is a very common multithreading primitive that nearly every multithreading library implements. A ParallelFor will split each of the iterations of a for loop into multiple cores automatically. Given that UpdateAnimation is done on each character and its standalone, we can use it here. 
+There is something we can use here that will work great, known as a ParallelFor. ParallelFor is a very common multithreading primitive that nearly every multithreading library implements. A ParallelFor will split each of the iterations of a for loop into multiple cores automatically. Given that UpdateAnimation is done on each character and it's standalone, we can use it here. 
 
 Cpp17 added parallelized std::algorithms, which are awesome, but only implemented in Visual Studio for now. You can play around with them if you use VS, but if you want multiplatform, you will need to find alternatives. You can find some more information about the parallel algorithms here [7](https://devblogs.microsoft.com/cppblog/using-c17-parallel-algorithms-for-better-performance/), and if you want to learn about std::algorithms in general, this cppcon talk gives a overview [8](https://www.youtube.com/watch?v=2olsGf6JIkU)
 
@@ -129,7 +129,7 @@ One of the parallel algorithms is `std::for_each()`, which is the parallel for w
 
 ```cpp
 
-std::for_each(std::execution::par, //we need the execution::par for this foreach to execute parallel. Its on the <execution> header
+std::for_each(std::execution::par, //we need the execution::par for this foreach to execute parallel. It's on the <execution> header
             AICharacters.begin(),
             AICharacters.end(),
             [](AICharacter* AiChar){ //cpp lambda that executes for each element in the AICharacters container.
@@ -213,22 +213,22 @@ With this, we are defining a graph of tasks, and their dependencies for executio
 
 Having sections of the frame that bottleneck the tasks and have to run in one core only is very common, so what most engines do is that they still have game thread and render thread, but each of them has its own parallel tasks. Hopefully there are enough tasks that can run on their own to fill all of the cores.
 
-While the example here uses async, you really want to use better libraries for this. Its also probable that you will want a better control over execution instead of launching many asyncs and parallel for. Using Taskflow here would work great.
+While the example here uses async, you really want to use better libraries for this. It's also probable that you will want a better control over execution instead of launching many asyncs and parallel for. Using Taskflow here would work great.
 
 ## Identifying tasks.
 While we have been commenting that things like UpdatePhysics() can run overlapped, things are never so simple in practice. 
-Identifying what tasks can run at the same time as others is something very hard to do in a project, and in Cpp, its not possible to validate it. If you use rust, this comes automatically thanks to the borrowcheck model. 
+Identifying what tasks can run at the same time as others is something very hard to do in a project, and in Cpp, it's not possible to validate it. If you use rust, this comes automatically thanks to the borrowcheck model. 
 
 A common way to know that a given task can run alongside another one is to "package" the data the task could need, and make sure that the task NEVER accesses any other data outside of it. In the example with game thread and render thread, we have a Renderer class where all the render data is stored, and the game thread never touches that. We also only let the render thread access the gamethread data at a very specific point in the frame where we know the gamethread isn't working on it.
 
 For most tasks, there are places where we just cant guarantee that only one task is working on it at a time, and so we need a way of synchronizing data between the different tasks run at the same time on multiple cores.
 
 ## Synchronizing data.
-There are a lot of ways of synchronizing the data tasks work on. Generally you really want to minimize the shared data a lot, as its a source of bugs, and can be horrible if not synchronized properly. There are a few patterns that do work quite well that can be used. 
+There are a lot of ways of synchronizing the data tasks work on. Generally you really want to minimize the shared data a lot, as it's a source of bugs, and can be horrible if not synchronized properly. There are a few patterns that do work quite well that can be used. 
 
 A common one is to have tasks publish messages into queues, and then another task can read it at other point. Lets say that our Particles from above need to be deleted, but the particles are stored in an array, and deleting a particle from that array when the other threads are working on other particles of the same array is a guaranteed way to make the program crash. We could insert the particle IDs into a shared synchronized queue, and after all particles finished their work, delete the particles from that queue.
 
-We are not going to look at the implementation details of the queue. Lets say its a magic queue where you can safely push elements into from multiple cores at once. There are lots of those queues around. I've used Moodycamel Concurrent Queue a lot for this purpose [10](https://github.com/cameron314/concurrentqueue)
+We are not going to look at the implementation details of the queue. Let's say it's a magic queue where you can safely push elements into from multiple cores at once. There are lots of those queues around. I've used Moodycamel Concurrent Queue a lot for this purpose [10](https://github.com/cameron314/concurrentqueue)
 
 pseudocode
 ```cpp
@@ -255,7 +255,7 @@ auto particles_task = std::async(std::launch::async,
 
 particles_task.wait();
 
-//after waiting for the particles task, there is nothing else that touches the particles, so its safe to apply the deletions
+//after waiting for the particles task, there is nothing else that touches the particles, so it's safe to apply the deletions
 for(Particle* Part : deletion_queue)
 {
     Part->Remove();
@@ -299,20 +299,20 @@ std::for_each(std::execution::par,
 
 ```
 
-In this example, if we were using a normal integer, the count will very likely be wrong, as each thread will add a different value and its very likely that one thread will override another thread, but in here, we are using `atomic<int>`, which is guaranteed to have the correct value in a case like this. Atomic numbers also implement more abstract operations such as Compare and Swap, and Fetch Add, which can be used to implement synchronized data structures, but doing that properly is for the experts, as its some of the hardest things you can try to implement yourself.
+In this example, if we were using a normal integer, the count will very likely be wrong, as each thread will add a different value and it's very likely that one thread will override another thread, but in here, we are using `atomic<int>`, which is guaranteed to have the correct value in a case like this. Atomic numbers also implement more abstract operations such as Compare and Swap, and Fetch Add, which can be used to implement synchronized data structures, but doing that properly is for the experts, as it's some of the hardest things you can try to implement yourself.
 
 When used wrong, atomic variables will error in very subtle ways depending on the hardware of the CPU. Debugging this sort of errors can be hard to do. 
 
 A great presentation about using atomics to implement synchronized data structures, and how hard it really is, is this talk from Cppcon. [11](https://www.youtube.com/watch?v=c1gO9aB9nbs). For a more in-depth explanation about how exactly std atomic works, this other talk explains it well. [12](https://www.youtube.com/watch?v=ZQFzMfHIxng)
 
-To actually synchronize data structures or multithreaded access to something its better to use mutexes.
+To actually synchronize data structures or multithreaded access to something it's better to use mutexes.
 
 
 ## Mutex
 
 A mutex is a higher level primitive that is used to control the execution flow on threads. You can use them to make sure that a given operation is only being executed by one thread at a time. API details can be found here [13](https://en.cppreference.com/w/cpp/thread/mutex)
 
-Mutexes are implemented using atomics, but if they block a thread for a long time, they can ask the OS to put that thread on the background and let a different thread execute. This can be expensive, so mutexes are best used on operations that you know wont block too much.
+Mutexes are implemented using atomics, but if they block a thread for a long time, they can ask the OS to put that thread on the background and let a different thread execute. This can be expensive, so mutexes are best used on operations that you know won't block too much.
 
 Continuing with the example, we are going to implement the parallel queue above as a normal vector, but protected with a mutex.
 
@@ -350,9 +350,9 @@ Cpp mutexes have a Lock and Unlock function, and there is also a try_lock functi
 
 Only one thread at a time can lock the mutex. If a second thread tries to lock the mutex, then that second thread will have to wait until the mutex unlocks. This can be used to define sections of code that are guaranteed to only be executed for one thread at a time.
 
-Whenever mutexes are used, its very important that they are locked for a short amount of time, and unlocked as soon as possible. If you are using a task system, its imperative that all mutexes are unlocked before the task finishes, as if a task finishes without unlocking a mutex it will block everything.
+Whenever mutexes are used, its very important that they are locked for a short amount of time, and unlocked as soon as possible. If you are using a task system, it's imperative that all mutexes are unlocked before the task finishes, as if a task finishes without unlocking a mutex it will block everything.
 
-Mutexes have the great issue that if they are used wrong, the program can completely block itself. This is known as a Deadlock, and its very easy to have it on code that looks fine but at some point in some case 2 threads can lock each other.
+Mutexes have the great issue that if they are used wrong, the program can completely block itself. This is known as a Deadlock, and it's very easy to have it on code that looks fine but at some point in some case 2 threads can lock each other.
 
 There are ways to avoid deadlocks, one of the most straightforward one is that any time you use a mutex you shouldn't take another mutex unless you know what you are doing, and any time you lock a mutex you unlock it asap.
 
@@ -373,7 +373,7 @@ if(Part->IsDead)
 
 
 ## Multithreading Vulkan
-We have explained the ways one can parallelize things in the engine, but what about GPU calls themselves? If we were talking about OpenGL, there would be absolutely nothing you can do. In OpenGL or other older APIs, its only possible to do API calls from one thread. Not even one thread at a time, but one specific thread. For those APIs, renderers often created a dedicated OpenGL/API thread that would execute the commands that other threads sent to it. You can see that on both the Doom3 engine and the UE4 engine.
+We have explained the ways one can parallelize things in the engine, but what about GPU calls themselves? If we were talking about OpenGL, there would be absolutely nothing you can do. In OpenGL or other older APIs, it's only possible to do API calls from one thread. Not even one thread at a time, but one specific thread. For those APIs, renderers often created a dedicated OpenGL/API thread that would execute the commands that other threads sent to it. You can see that on both the Doom3 engine and the UE4 engine.
 
 On more modern APIs like Vulkan and DX12, we have a design that is meant to be used from multiple cores. In the case of Vulkan, the spec defines some rules about what resources must be protected and not used at once. We are going to see some typical examples of the kind of things you can multithread in Vulkan, and their rules.
 
@@ -429,10 +429,10 @@ vkEndCommandBuffer(primaryBuffer);
 
 This scheme of synchronizing the Vulkan subcommands and their resources can be tricky to get right, and Vulkan command encoding is very very fast, so you aren't optimizing much here. Some engines implement their own command buffer abstraction that is easier to handle from multiple threads, and then a recording thread will very quickly transform those abstracted commands into Vulkan. 
 
-Because Vulkan commands record so fast, recording from multiple threads wont be a big optimization. But your renderer isn't just recording commands in a deep loop, you have to do a lot more work. By splitting the command recording across multiple threads, then you can multithread your renderer internals in general much better. Doom eternal is known to do this.
+Because Vulkan commands record so fast, recording from multiple threads won't be a big optimization. But your renderer isn't just recording commands in a deep loop, you have to do a lot more work. By splitting the command recording across multiple threads, then you can multithread your renderer internals in general much better. Doom eternal is known to do this.
 
 Data upload is another section that is very often multithreaded. In here, you have a dedicated IO thread that will load assets to disk, and said IO thread will have its own queue and command allocators, hopefully a transfer queue. This way it is possible to upload assets at a speed completely separated from the main frame loop, so if it takes half a second to upload a set of big textures, you don't have a hitch. 
-To do that, you need to create a transfer or async-compute queue (if available), and dedicate that one to the loader thread. Once you have that, its similar to what was commented on the pipeline compiler thread, and you have an IO thread that communicates through a parallel queue with the main simulation loop to upload data in an asynchronous way. Once a transfer has been uploaded, and checked that it has finished with a Fence, then the IO thread can send the info to the main loop, and then the engine can connect the new textures or models into the renderer.
+To do that, you need to create a transfer or async-compute queue (if available), and dedicate that one to the loader thread. Once you have that, it's similar to what was commented on the pipeline compiler thread, and you have an IO thread that communicates through a parallel queue with the main simulation loop to upload data in an asynchronous way. Once a transfer has been uploaded, and checked that it has finished with a Fence, then the IO thread can send the info to the main loop, and then the engine can connect the new textures or models into the renderer.
 
 
 

--- a/docs/gpudriven/code_architecture.md
+++ b/docs/gpudriven/code_architecture.md
@@ -7,9 +7,9 @@ nav_order: 3
 
 # Code map
 
-To find the code that implements all of the draw indirect improvements, its on the "engine" branch of the github repo. For a direct link, here it is: [Repo](https://github.com/vblanco20-1/vulkan-guide/tree/engine)
+To find the code that implements all of the draw indirect improvements, it's on the "engine" branch of the github repo. For a direct link, here it is: [Repo](https://github.com/vblanco20-1/vulkan-guide/tree/engine)
 
-The codebase continues from where Chapter 5 left off, but a lot of improvements and abstractions were added to it. Everything in the "Extra" chapter is on here, and there are a few things that dont have an article on Extra chapter.
+The codebase continues from where Chapter 5 left off, but a lot of improvements and abstractions were added to it. Everything in the "Extra" chapter is on here, and there are a few things that don't have an article on Extra chapter.
 
 * Imgui support: Added imgui UI to the engine, can be found mostly on VulkanEngine class. Explained [here]({{ site.baseurl }}{% link docs/extra-chapter/implementing_imgui.md %})
 * CVars.h/cpp: Implements a CVar system for some configuration variables. Explained in [here]({{ site.baseurl }}{% link docs/extra-chapter/cvar_system.md %}). The implementation in here also has support for tweaking the variables in Imgui.
@@ -32,7 +32,7 @@ The main engine render loop is similar to the one after the chapters, but a lot 
 
 When the engine initializes, it loads some prefabs and spawns them into the world as MeshObjects, which it injects into the RenderScene that will then add the objects into the multiple mesh passes according to materials and configuration. 
 
-There are 3 mesh passes handled. Forward pass handles the "opaque" rendering of objects, Transparent handles the translucent objects, and draws after the opaque objects are finished. Then there is the Shadow pass that will render a sun shadow. MeshObjects will register into these 3 passes according to their setup. Opaque objects will be added to Forward and Shadow passes, while translucent objects will only register into the Transparent pass, as we dont want the translucent objects to cast shadow.
+There are 3 mesh passes handled. Forward pass handles the "opaque" rendering of objects, Transparent handles the translucent objects, and draws after the opaque objects are finished. Then there is the Shadow pass that will render a sun shadow. MeshObjects will register into these 3 passes according to their setup. Opaque objects will be added to Forward and Shadow passes, while translucent objects will only register into the Transparent pass, as we don't want the translucent objects to cast shadow.
 
 Once the engine is loaded, `RenderScene::build_batches()` and `RenderScene::merge_meshes()` are called at the end of engine initialization. build_batches will process all the mesh passes and prepare their indirect draw commands. merge_meshes will grab the vertex buffers of each of the meshes registered with the RenderScene, and merge them into a huge vertex buffer. This allows us to bind the vertex buffer once per mesh pass and never touch it again.
 

--- a/docs/gpudriven/compute_culling.md
+++ b/docs/gpudriven/compute_culling.md
@@ -86,7 +86,7 @@ bool IsVisible(uint objectIndex)
 }
 ```
 
-For all of the `cullData`, thats written from the Cpp when calling the compute shader. It holds the frustrum data and the configuration for the culling.
+For all of the `cullData`, that's written from the Cpp when calling the compute shader. It holds the frustrum data and the configuration for the culling.
 
 We begin by grabbing the object sphereBounds from the objectIndex. The spherebounds are calculated every time the object moves, or is initialized. 
 
@@ -96,7 +96,7 @@ If the checks pass, then all is good, and we can return visible to use when writ
 Frustrum culling will easily cut half the objects, but we can go much further. 
 
 ## Occlusion Culling
-We want to avoid rendering objects that wont be visible at all due to them being behind other objects. To do that, we are going to implement occlusion culling using the depth buffer from the last frame. This is a very common technique with the downside of having 1 frame of latency. Some engines instead render a few bigger objects, and then use that depth buffer to do culling.
+We want to avoid rendering objects that won't be visible at all due to them being behind other objects. To do that, we are going to implement occlusion culling using the depth buffer from the last frame. This is a very common technique with the downside of having 1 frame of latency. Some engines instead render a few bigger objects, and then use that depth buffer to do culling.
 
 The normal depth buffer is too detailed for doing efficient culling, so we need to convert it into a depth pyramid.
 The idea of a depth pyramid is that we build a mipmap chain for the depth buffer in a way that the depth values are allways the maximum depth of that region. That way, we can look up directly into a mipmap so that pixel size is similar to object size, and it gives us a fairly accurate approximation.
@@ -182,7 +182,7 @@ void main()
 ```
 
 The real trick on it is the sampler for the texture. In here, we are using a commonly found extension that will calculate the minimum of a 2x2 texel quad, instead of averaging the values like a LINEAR mipmap does.
-The sampler will also be used in the cull shader, and its created like this.
+The sampler will also be used in the cull shader, and it's created like this.
 
 ```cpp
 	VkSamplerCreateInfo createInfo = {};
@@ -209,7 +209,7 @@ The sampler will also be used in the cull shader, and its created like this.
 	VK_CHECK(vkCreateSampler(_device, &createInfo, 0, &_depthSampler));
 ```
 
-This is a extension that will have to be enabled, but its supported everywhere, even on switch. In vulkan 1.2, its a default feature. [Spec](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_sampler_filter_minmax.html)
+This is a extension that will have to be enabled, but its supported everywhere, even on switch. In vulkan 1.2, it's a default feature. [Spec](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_sampler_filter_minmax.html)
 
 
 With the depth pyramid written, we can finally use it in the cull shader.
@@ -247,7 +247,7 @@ With the depth pyramid written, we can finally use it in the cull shader.
 
 We are finding the AABB that covers the sphere in screen space, and then accessing the depth pyramid at that point, in the mipmap where the size of the AABB is similar to a pixel. 
 
-This depth pyramid logic is very similar if not almost exactly the same as the cull system used in unreal engine. In there, they dont have draw indirect, so instead they do the cull in a shader, and output into an array of visible objects. This array is then read from the CPU to know what objects are visible or not.
+This depth pyramid logic is very similar if not almost exactly the same as the cull system used in unreal engine. In there, they don't have draw indirect, so instead they do the cull in a shader, and output into an array of visible objects. This array is then read from the CPU to know what objects are visible or not.
 
 With this last piece of the puzzle, the engine can now render huge scenes at really high perf, because it will only render whatever is visible on the screen, but without a roundtrip to the CPU. 
 
@@ -259,7 +259,7 @@ Sadly, doing culling and sorting at the same time is a really hard problem, so i
 The culling uses GPU atomics, whose order depends on how the threads are executed in the GPU hardware. This means it has no stability at all for sorting, and the final layout of the rendering will be different.
 
 Even then, there are ways of working around it.
-If instead of doing the draw indirect using instancing we have 1 draw command per object, and set its instance count to 0 if culled, we can keep the order. But if we do that, we will have 0 sized draws which will still cost performance in the engine, so its not that good of a solution.
+If instead of doing the draw indirect using instancing we have 1 draw command per object, and set its instance count to 0 if culled, we can keep the order. But if we do that, we will have 0 sized draws which will still cost performance in the engine, so it's not that good of a solution.
 
 Another possibility is to sort in the gpu itself, but gpu sorting is a nontrivial operation, so we arent doing it in the tutorial due to it being off scope.
 

--- a/docs/gpudriven/draw_indirect.md
+++ b/docs/gpudriven/draw_indirect.md
@@ -55,9 +55,9 @@ typedef struct VkDrawIndirectCommand {
 
 ```
 
-Its important to know that you dont need to have the data be a packed array of command structs. You can have more things in the buffer, as long as you set the offset and stride correctly. In the engine we store extra data in the buffer.
+It's important to know that you don't need to have the data be a packed array of command structs. You can have more things in the buffer, as long as you set the offset and stride correctly. In the engine we store extra data in the buffer.
 
-To create a draw-indirect buffer, it can be on both CPU side and GPU side buffers, and it doesnt really matter that much which one it is if you are doing read-only. In the engine we have the draw-indirect buffer in the gpu because we are writing to it from the culling compute shaders.
+To create a draw-indirect buffer, it can be on both CPU side and GPU side buffers, and it doesn't really matter that much which one it is if you are doing read-only. In the engine we have the draw-indirect buffer in the gpu because we are writing to it from the culling compute shaders.
 
 Here you can see an example of creating a CPU-writeable indirect buffer
 ```cpp
@@ -90,7 +90,7 @@ void FakeDrawIndirect(VkCommandBuffer commandBuffer,void* buffer,VkDeviceSize of
 }   
 ```
 
-There is also a very popular extension that makes draw indirect even more powerful known as DrawIndirectCount. The extension is a default feature in Vulkan 1.2, and works on pretty much all PC hardware. Sadly, its not supported in nintendo switch, so the tutorial will not use it.
+There is also a very popular extension that makes draw indirect even more powerful known as DrawIndirectCount. The extension is a default feature in Vulkan 1.2, and works on pretty much all PC hardware. Sadly, it's not supported in nintendo switch, so the tutorial will not use it.
 Draw Indirect Count is the same as a normal draw indirect call, but "drawCount" is grabbed from another buffer. This makes it possible to let the GPU decide how many draw indirect commands to draw, which makes it possible to remove culled draws easily so that there is no wasted work.
 
 
@@ -120,7 +120,7 @@ The Render loop looks like this by the end of chapter 4 (pseudocode)
 	{
 		RenderObject& object = objects[i];
 
-		//only bind the pipeline if it doesnt match with the already bound one
+		//only bind the pipeline if it doesn't match with the already bound one
 		if (object.material != lastMaterial) {
 
 			bind_descriptors(object.material);
@@ -215,7 +215,7 @@ With the draws compacted in this way, we can rewrite the draw loop into this, wh
 
 Note how now we have a direct vkCmdDraw() loop. This maps exactly to a draw indirect command. With the loop like this, we can now write the commands, and execute it that way. 
 
-Im assuming the indirect buffer is allocated as shown above, but using VkDrawIndirectCommand, instead of VkDrawInstancedIndirectCommand. as in the chapter 4 code base indexed rendering wasnt implemented.
+I'm assuming the indirect buffer is allocated as shown above, but using VkDrawIndirectCommand, instead of VkDrawInstancedIndirectCommand. as in the chapter 4 code base indexed rendering wasn't implemented.
 
 
 ```cpp
@@ -252,8 +252,8 @@ for (IndirectBatch& draw : draws)
     vkCmdDrawIndirect(cmd,get_current_frame().indirectBuffer,indirect_offset, draw.count,draw_stride);
 }
 ```
-Thats it, now the render loop is indirect and should go a bit faster. But the most important think to take into account here, is that the draw commands buffer can be cached and written/read from compute shaders. If you wanted, you can just write it once at load, and just do the loop of vkCmdDrawIndirect every frame. This is also a design where adding culling is extremelly simple.
-You just do a compute shader that sets instanceCount to 0 if the object is culled, and thats it. But keep in mind such a thing is not very optimal given that empty draw commands still have overhead, so its better to compact them somehow, either by using a design that uses instancing (like what we are doing in the tutorial engine), or by using DrawIndirectCount after removing the empty draws.
+That's it, now the render loop is indirect and should go a bit faster. But the most important think to take into account here, is that the draw commands buffer can be cached and written/read from compute shaders. If you wanted, you can just write it once at load, and just do the loop of vkCmdDrawIndirect every frame. This is also a design where adding culling is extremelly simple.
+You just do a compute shader that sets instanceCount to 0 if the object is culled, and that's it. But keep in mind such a thing is not very optimal given that empty draw commands still have overhead, so it's better to compact them somehow, either by using a design that uses instancing (like what we are doing in the tutorial engine), or by using DrawIndirectCount after removing the empty draws.
 
 There is also something you can see very clearly there. The less combinations of mesh buffer, descriptors, and pipeline you have, the more you can draw on each DrawIndirect execution. This is why generally you want your draws to to be as bindless as possible when doing draw indirect. 
 

--- a/docs/gpudriven/gpu_driven_engines.md
+++ b/docs/gpudriven/gpu_driven_engines.md
@@ -79,7 +79,7 @@ To move textures into bindless, you use texture arrays. With the correct extensi
 
 To make materials bindless, you need to stop having 1 pipeline per material. Instead, you want to move the material parameters into SSBOs, and go with an ubershader approach. In the Doom engines, they have a very low amount of pipelines for the entire game. Doom eternal has less than 500 pipelines, while Unreal Engine games often have 100.000+ pipelines. If you use ubershaders to massively lower the amount of unique pipelines, you will be able to increase efficiency in a huge way, as VkCmdBindPipeline is one of the most expensive calls when drawing objects in vulkan.
 
-Push Constants and Dynamic Descriptors can be used, but they have to be "global". Using pushconstants for things like camera location is perfectly fine, but you cant use them for object ID as thats a per-object call and you specifically want to draw as many objects as possible in 1 draw.
+Push Constants and Dynamic Descriptors can be used, but they have to be "global". Using pushconstants for things like camera location is perfectly fine, but you cant use them for object ID as that's a per-object call and you specifically want to draw as many objects as possible in 1 draw.
 
 The general workflow is to put stuff into buffers, and have big buffers so you don't need to bind them every call. The bonus is that you can also write those buffers from the GPU, which is what Dragon Age Inquisition does for Index buffers, where it writes to them from the culling shaders so that only the visible triangles get drawn.
 

--- a/docs/gpudriven/material_system.md
+++ b/docs/gpudriven/material_system.md
@@ -5,15 +5,15 @@ parent: GPU Driven Rendering
 nav_order: 8
 ---
 
-For the engine, we start to have multiple passes of rendering, so its time to create an actual material system.
+For the engine, we start to have multiple passes of rendering, so ' time to create an actual material system.
 Material systems are notoriously hard to architect in rendering engines, due to their need to balance many things (flexibility, ease of use, batching), with many different parts of the engine.
 
-In the engine, the system used is a fairly simple one, but does its job for now. Its not the best solution, but its a solution that works in this use case.
+In the engine, the system used is a fairly simple one, but does its job for now. It's not the best solution, but it's a solution that works in this use case.
 
 
 The material system can be found on the `material_system.h/cpp` pair, but it also depends on the descriptor system and shader reflection system.
 
-Its based on the same core logic as the original material system shown in the main tutorial chapters. A material will contain the pipeline and shaders, alongside a descriptor set for slot 2 which will be used for textures.
+It's based on the same core logic as the original material system shown in the main tutorial chapters. A material will contain the pipeline and shaders, alongside a descriptor set for slot 2 which will be used for textures.
 
 ## Shader Effect
 ```cpp
@@ -160,15 +160,15 @@ struct MaterialData {
 	}
 ```
 
-Its incredibly common with most GLTF and FBX files that you will have the same materials under different names. This is even more common when loading multiple prefabs, where its likely that some materials are the same. 
+It's incredibly common with most GLTF and FBX files that you will have the same materials under different names. This is even more common when loading multiple prefabs, where it's likely that some materials are the same. 
 To improve this, the material system is very heavily cached.
-The `build_material` function is a lie, and will first try to find if there is a material that is the same to what you want to create. It will only create the material and properly build the texture descriptors if its a unique combination. This way, materials get merged constantly, which makes it much better to use from a draw indirect batching standpoint.
+The `build_material` function is a lie, and will first try to find if there is a material that is the same to what you want to create. It will only create the material and properly build the texture descriptors if it's a unique combination. This way, materials get merged constantly, which makes it much better to use from a draw indirect batching standpoint.
 
 ```cpp
 vkutil::Material* vkutil::MaterialSystem::build_material(const std::string& materialName, const MaterialData& info)
 {
 	Material* mat;
-	//search material in the cache first in case its already built
+	//search material in the cache first in case it's already built
 	auto it = materialCache.find(info);
 	if (it != materialCache.end())
 	{
@@ -231,7 +231,7 @@ if (object->bDrawShadowPass)
 
 The only thing that is needed for rendering is the pipeline ID and the descriptor set ID, for that reason the mesh renderer in `vk_scene.cpp` will "unpack" the layers of the material, and eventually only store what is needed. By doing that, the materials that share the same pipeline ID are "merged" together when the system sorts the meshes, and will batch much better together.
 
-Because the shadow pass uses allways the same default opaque-shadow effect, and it has no textures (null descriptor set), the shadow pass in the engine will allways render in a single drawcall. Even if the scene is composed of multiple different materials, when its time to render, the system will see that pipeline is allways the same, so it will only be one drawcall.
+Because the shadow pass uses allways the same default opaque-shadow effect, and it has no textures (null descriptor set), the shadow pass in the engine will allways render in a single drawcall. Even if the scene is composed of multiple different materials, when it's time to render, the system will see that pipeline is allways the same, so it will only be one drawcall.
 
 
 

--- a/docs/gpudriven/mesh_rendering.md
+++ b/docs/gpudriven/mesh_rendering.md
@@ -9,7 +9,7 @@ Now that the material system is explained, we can go forward to the meat of it, 
 
 Most of the system code is on `vk_scene.h/cpp` files. The part that does the rendering commands for it is done in `vk_engine_scenerender.h/cpp` files.
 
-The design of the system is inspired by work shown in Unreal Engine and OurMachinery blogs and presentations. Its not the best solution, but its one that does work fairly well.
+The design of the system is inspired by work shown in Unreal Engine and OurMachinery blogs and presentations. It's not the best solution, but it's one that does work fairly well.
 
 
 ## Mesh Passes
@@ -53,7 +53,7 @@ struct RenderBatch {
 		uint64_t sortKey;
 ```
 
-Flat_batches is the individual non-instanced draws for every object in the pass. This one can get very big if there are enough objects. If you dont want to use draw indirect, you can render this array directly. They are just a handle to the objects array + the calculated sort key. Flat-batches array will be kept in-order allways.
+Flat_batches is the individual non-instanced draws for every object in the pass. This one can get very big if there are enough objects. If you don't want to use draw indirect, you can render this array directly. They are just a handle to the objects array + the calculated sort key. Flat-batches array will be kept in-order allways.
 
 ```cpp
 struct IndirectBatch {
@@ -170,14 +170,14 @@ Handle<RenderObject> RenderScene::register_object(MeshObject* object)
 }
 ```
 
-When adding an object into a given meshpass, it looks up if the material actually has shaders for that type of pass. An object whose material is transparent will be registered into the transparent meshpass, and an object that doesnt have a DirectionalShadow shader effect wont cast shadows.
+When adding an object into a given meshpass, it looks up if the material actually has shaders for that type of pass. An object whose material is transparent will be registered into the transparent meshpass, and an object that doesn't have a DirectionalShadow shader effect won't cast shadows.
 
-This is done so that each pass is fully standalone and doesnt do any work it doesnt have to. In the test scenes, there are generally very few transparent objects, so the transparent meshpass is always very lightweight.
+This is done so that each pass is fully standalone and doesn't do any work it doesn't have to. In the test scenes, there are generally very few transparent objects, so the transparent meshpass is always very lightweight.
 
 
 ## Meshpass update logic
 
-When objects are added or removed from a meshpass, the meshpass needs to update its main flat_batches array, and its parents. This is done from the `refresh_pass` function, which has to be whenever there are changes to apply. Its not necesary to call this every frame, and its safe to call from multiple threads.
+When objects are added or removed from a meshpass, the meshpass needs to update its main flat_batches array, and its parents. This is done from the `refresh_pass` function, which has to be whenever there are changes to apply. It's not necesary to call this every frame, and it's safe to call from multiple threads.
 
 The code in the repo for this part is still work in progress, and the optimizations done around partial updates can be tricky to follow. But the general logic works like this for the full-rebuild.
 
@@ -187,7 +187,7 @@ Once the PassObject array is filled, we go over it, and calculate the draw hashe
 
 Once we have the flat_batches array sorted, we go over it, and compact the draws into the IndirectBatch array. Multiple draws in the flat_batches array will become a single IndirectBatch, which is an instanced draw.
 
-After that array is made, its compacted again into the multibatch array.
+After that array is made, it's compacted again into the multibatch array.
 
 
 ## GPU Side buffers
@@ -215,7 +215,7 @@ AllocatedBuffer<GPUIndirectObject> clearIndirectBuffer;
 `drawIndirectBuffer` and `clearIndirectBuffer` are both created from the meshpass batches array,and they hold the draw-indirect commands.
 `clearIndirectBuffer` is a CPU-writeable buffer, and it has the correct data, but with `command.instanceCount` set to 0. From the culling shader we keep adding instances, so we use this one to "reset" `drawIndirectBuffer` every frame.
 
-`drawIndirectBuffer` is a GPU-side buffer, and its the one we actually use for rendering. 
+`drawIndirectBuffer` is a GPU-side buffer, and it's the one we actually use for rendering. 
 
 `passObjectsBuffer` is the main array used for the GPU compute pass. Each of the GPUInstance objects holds objectID and batchID. batchID will be used to access the proper draw-command if the cull passes, and object ID is just the global index of the object, to access its data.
 

--- a/docs/introduction/vulkan_overview.md
+++ b/docs/introduction/vulkan_overview.md
@@ -27,7 +27,7 @@ Although this tutorial is written in C++, porting it to other low level language
 ## When to use Vulkan
 
 If your main bottleneck is GPU-side, it is unlikely that implementing Vulkan will improve performance enough to be worth it.
-It should be mentioned that Vulkan is significantly harder to use compared to OpenGL, and its extra complexity often means longer development times.
+It should be mentioned that Vulkan is significantly harder to use compared to OpenGL, and it's extra complexity often means longer development times.
 
 If your application consists of big maps, dynamic worlds, or CAD type scenes with a lot of objects, then Vulkan's multithreaded capabilities will likely boost performance.
 


### PR DESCRIPTION
I found the text very hard to read due to the lack of apostrophes to differentiate `it's` from `its`. This PR picks off the low hanging fruit via find-and-replace. [Here's](https://www.dummies.com/education/language-arts/grammar/how-to-use-apostrophes-to-form-contractions/) a guide to contractions in English which might be useful.