### PR TITLE
add msaa parameter to imgui init info

### DIFF
--- a/docs/extra-chapter/implementing_imgui.md
+++ b/docs/extra-chapter/implementing_imgui.md
@@ -87,6 +87,7 @@ void VulkanEngine::init_imgui()
 	init_info.DescriptorPool = imguiPool;
 	init_info.MinImageCount = 3;
 	init_info.ImageCount = 3;
+	init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
 
 	ImGui_ImplVulkan_Init(&init_info, _renderPass);
 


### PR DESCRIPTION
This will make it easier to add multisampling later on, so that doing a ctrl+f search for "VK_SAMPLE_COUNT_1_BIT" will find this too. If someone doesn't know this field exists in imgui init info, they may think they need to make another renderpass just for imgui to do multisampling.