### PR TITLE
Fix SDL_PATH in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required (VERSION 3.8)
 
 project ("vulkan_guide")
 
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(Vulkan REQUIRED)
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(tinyobjloader PUBLIC tinyobjloader)
 
 
 add_library(sdl2 INTERFACE)
-set(sdl2_DIR "SDL_PATH" CACHE FILEPATH "Path to SDL2")
+set(sdl2_DIR "SDL_PATH" CACHE PATH "Path to SDL2")
 
 if (WIN32)
 target_include_directories(sdl2 INTERFACE ${sdl2_DIR}/include ${sdl2_image_DIR}/include)


### PR DESCRIPTION
Use PATH instead of FILEPATH for setting SDL folder.
Fix VMA compile error by explicitly using C++17