### PR TITLE
Allocate transfer command buffer ahead of time and re-use

### DIFF
--- a/chapter-5/vk_engine.cpp
+++ b/chapter-5/vk_engine.cpp
@@ -474,6 +474,11 @@ void VulkanEngine::init_commands()
 	_mainDeletionQueue.push_function([=]() {
 		vkDestroyCommandPool(_device, _uploadContext._commandPool, nullptr);
 	});
+
+	//allocate the default command buffer that we will use for rendering
+	VkCommandBufferAllocateInfo cmdAllocInfo = vkinit::command_buffer_allocate_info(_uploadContext._commandPool, 1);
+
+	VK_CHECK(vkAllocateCommandBuffers(_device, &cmdAllocInfo, &_uploadContext._commandBuffer));
 }
 
 void VulkanEngine::init_sync_structures()
@@ -1115,13 +1120,7 @@ size_t VulkanEngine::pad_uniform_buffer_size(size_t originalSize)
 
 void VulkanEngine::immediate_submit(std::function<void(VkCommandBuffer cmd)>&& function)
 {
-	VkCommandBuffer cmd;
-
-	//allocate the default command buffer that we will use for rendering
-	VkCommandBufferAllocateInfo cmdAllocInfo = vkinit::command_buffer_allocate_info(_uploadContext._commandPool, 1);
-
-	VK_CHECK(vkAllocateCommandBuffers(_device, &cmdAllocInfo, &cmd));
-
+	VkCommandBuffer cmd =_uploadContext._commandBuffer;
 	//begin the command buffer recording. We will use this command buffer exactly once, so we want to let vulkan know that
 	VkCommandBufferBeginInfo cmdBeginInfo = vkinit::command_buffer_begin_info(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 

--- a/chapter-5/vk_engine.h
+++ b/chapter-5/vk_engine.h
@@ -96,6 +96,7 @@ struct FrameData {
 struct UploadContext {
 	VkFence _uploadFence;
 	VkCommandPool _commandPool;	
+	VkCommandBuffer _commandBuffer;
 };
 struct GPUCameraData{
 	glm::mat4 view;


### PR DESCRIPTION
The old version was leaking command buffer handles because vkResetCommandPool does not free
the allocated command buffers. Now we simply create one ahead of time and re-use it over and
over.