### PR TITLE
Add subpass dependency to ensure synchronization across frames

### DIFF
--- a/docs/chapter-3/depth_buffer.md
+++ b/docs/chapter-3/depth_buffer.md
@@ -277,46 +277,24 @@ Now we have to adjust the renderpass synchronization. Previously, it was possibl
 We add two new subpass dependencies on the `init_default_renderpass()` function that synchronize accesses to depth attachments.
 
 ```cpp
-VkSubpassDependency depth_in_dependency = {};
-depth_in_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-depth_in_dependency.dstSubpass = 0;
-depth_in_dependency.srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-depth_in_dependency.srcAccessMask = 0;
-depth_in_dependency.dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-depth_in_dependency.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-
-
-VkSubpassDependency depth_out_dependency = {};
-depth_out_dependency.srcSubpass = 0;
-depth_out_dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
-depth_out_dependency.srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-depth_out_dependency.srcAccessMask = 0;
-depth_out_dependency.dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-depth_out_dependency.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+VkSubpassDependency depth_dependency = {};
+depth_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+depth_dependency.dstSubpass = 0;
+depth_dependency.srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+depth_dependency.srcAccessMask = 0;
+depth_dependency.dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+depth_dependency.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 ```
 
-These dependencies tell Vulkan that using the depth attachment in a renderpass cannot be done before previous renderpasses have finished using it.
+This dependency tells Vulkan that using the depth attachment in a renderpass cannot be done before previous renderpasses have finished using it.
 
-However, now that we explicitly have a dependency from subpass 0 to "outside", we also need to explicitly synchronize the layout transition of the color attachment that happens at the end of each subpass.
-
-We add another barrier accomplishing this job:
-```cpp
-VkSubpassDependency color_transition_dependency = {};
-color_transition_dependency.srcSubpass = 0;
-color_transition_dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
-color_transition_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-color_transition_dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-color_transition_dependency.dstStageMask = 0;
-color_transition_dependency.dstAccessMask = 0;
-```
-
-Now we need to include all four dependencies in the `VkRenderPassCreateInfo`:
+Now we need to include both dependencies in the `VkRenderPassCreateInfo`:
 
 ```cpp
-VkSubpassDependency dependencies[4] = { dependency, color_transition_dependency, depth_in_dependency, depth_out_dependency };
+VkSubpassDependency dependencies[2] = { dependency, depth_dependency };
 
 //other code...
-render_pass_info.dependencyCount = 4;
+render_pass_info.dependencyCount = 2;
 render_pass_info.pDependencies = &dependencies[0];
 ```
 

--- a/docs/chapter-3/depth_buffer.md
+++ b/docs/chapter-3/depth_buffer.md
@@ -274,7 +274,7 @@ Note how we are using the same depth image on each of the swapchain framebuffers
 
 Now we have to adjust the renderpass synchronization. Previously, it was possible that multiple frames were rendered simultaneously by the GPU. This is a problem when using depth buffers, because one frame could overwrite the depth buffer while a previous frame is still rendering to it.
 
-We add two new subpass dependencies on the `init_default_renderpass()` function that synchronize accesses to depth attachments.
+We add a new subpass dependency on the `init_default_renderpass()` function that synchronizes accesses to depth attachments.
 
 ```cpp
 VkSubpassDependency depth_dependency = {};


### PR DESCRIPTION
Currently, access to the depth attachment in the renderpasses is undersynchronized. 
The submits wait on a semaphore that is signaled when an acquired image is available - however, I failed to find any spec guarantee that this semaphore will be signaled only after rendering to a previous frame has finished, be it by waiting for the present operation to finish or just for it to start. I did find a section of the spec indicating that images may be acquired and presented out of order:
> There is no requirement for an application to present images in the same order that they were acquired - applications can arbitrarily present any image that is currently acquired.

(https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap33.html#vkQueuePresentKHR)
This, to me, indicates that acquiring images is generally independent from presenting them, and therefore, these two operations do not have to be synchronized. This theory is further supported by synchronization validation reporting write-after-write hazards (which would be expected in case of undersynchronization here), as pointed out in the comments for chapter 4 at https://github.com/vblanco20-1/vkguide-comments/issues/7#issuecomment-748338069 .

This PR fixes the undersynchronization (and the validation errors) by including depth attachment-related stages in the subpass dependencies for the main renderpass and adding another dependency from subpass 0 to external. I have also applied the relevant changes to the tutorial code, which will be included in another PR.