### PR TITLE
Fixes #59 - Use delete queue for uniform buffers

### DIFF
--- a/docs/chapter-4/descriptors_code.md
+++ b/docs/chapter-4/descriptors_code.md
@@ -105,7 +105,9 @@ void VulkanEngine::init_descriptors()
 	// add buffers to deletion queues
 	for (int i = 0; i < FRAME_OVERLAP; i++)
 	{
-		vmaDestroyBuffer(_allocator,_frames[i].cameraBuffer._buffer, _frames[i].cameraBuffer._allocation);
+		_mainDeletionQueue.push_function([&]() {
+			vmaDestroyBuffer(_allocator, _frames[i].cameraBuffer._buffer, _frames[i].cameraBuffer._allocation);
+		}
 	}
 }
 ```


### PR DESCRIPTION
I added a change to Chapter 4's descriptor code chapter but didn't use the deletion queue.