### PR TITLE
Usage of subpass dependencies for color attachments

### DIFF
--- a/docs/chapter-3/depth_buffer.md
+++ b/docs/chapter-3/depth_buffer.md
@@ -255,7 +255,19 @@ Instead of storing only the color attachment in pAttachments, we add the depth a
 
 Now we have to adjust the renderpass synchronization. Previously, it was possible that multiple frames were rendered simultaneously by the GPU. This is a problem when using depth buffers, because one frame could overwrite the depth buffer while a previous frame is still rendering to it.
 
-We add a new subpass dependency on the `init_default_renderpass()` function that synchronizes accesses to depth attachments.
+We keep the subpass dependency for the color attachment we were already using:
+
+```cpp
+VkSubpassDependency dependency = {};
+dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+dependency.dstSubpass = 0;
+dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+dependency.srcAccessMask = 0;
+dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+```
+
+We also add a new subpass dependency that synchronizes accesses to depth attachments.
 
 ```cpp
 VkSubpassDependency depth_dependency = {};


### PR DESCRIPTION
I was notified that in the current tutorial state, the section I added in #53 uses a subpass dependency for the color attachment without ever explaining it or showing code for the creation. This PR already fixes this by adding the code to create the dependency.  

However, that code is inherited from previous chapters, but is (to my knowledge) never explained anywhere. In chapter 1, explanation of the `pWaitDstStageMask` parameter that, in combination with the subpass dependency, makes the subpass wait on the image acquire semaphore, is deferred to another chapter:
> the .pWaitDstStageMask is a complex parameter. We are not going to explain it until we go into details of synchronization.

I haven't found the explanation for it in later chapters. I'd like this PR to fix this as well, though I'm not entirely sure in which chapter to place the explanation. Suggestions as to where this explanation should go are welcome.