### PR TITLE
fix minor copy paste typo

### DIFF
--- a/assetlib/material_asset.cpp
+++ b/assetlib/material_asset.cpp
@@ -6,17 +6,17 @@ assets::MaterialInfo assets::read_material_info(AssetFile* file)
 {
 	assets::MaterialInfo info;
 
-	nlohmann::json texture_metadata = nlohmann::json::parse(file->json);
-	info.baseEffect = texture_metadata["baseEffect"];
+	nlohmann::json material_metadata = nlohmann::json::parse(file->json);
+	info.baseEffect = material_metadata["baseEffect"];
 
 
-	for (auto& [key, value] : texture_metadata["textures"].items())
+	for (auto& [key, value] : material_metadata["textures"].items())
 	{
 
 		info.textures[key] = value;
 	}
 
-	for (auto& [key, value] : texture_metadata["customProperties"].items())
+	for (auto& [key, value] : material_metadata["customProperties"].items())
 	{
 
 		info.customProperties[key] = value;
@@ -24,8 +24,8 @@ assets::MaterialInfo assets::read_material_info(AssetFile* file)
 
 	info.transparency = TransparencyMode::Opaque;
 
-	auto it = texture_metadata.find("transparency");
-	if (it != texture_metadata.end())
+	auto it = material_metadata.find("transparency");
+	if (it != material_metadata.end())
 	{
 		std::string val = (*it);
 		if (val.compare("transparent") == 0) {
@@ -41,18 +41,18 @@ assets::MaterialInfo assets::read_material_info(AssetFile* file)
 
 assets::AssetFile assets::pack_material(MaterialInfo* info)
 {
-	nlohmann::json texture_metadata;
-	texture_metadata["baseEffect"] = info->baseEffect;
-	texture_metadata["textures"] = info->textures;
-	texture_metadata["customProperties"] = info->customProperties;
+	nlohmann::json material_metadata;
+	material_metadata["baseEffect"] = info->baseEffect;
+	material_metadata["textures"] = info->textures;
+	material_metadata["customProperties"] = info->customProperties;
 
 	switch (info->transparency)
 	{	
 	case TransparencyMode::Transparent:
-		texture_metadata["transparency"] = "transparent";
+		material_metadata["transparency"] = "transparent";
 		break;
 	case TransparencyMode::Masked:
-		texture_metadata["transparency"] = "masked";
+		material_metadata["transparency"] = "masked";
 		break;
 	}
 
@@ -67,7 +67,7 @@ assets::AssetFile assets::pack_material(MaterialInfo* info)
 	file.version = 1;
 
 
-	std::string stringified = texture_metadata.dump();
+	std::string stringified = material_metadata.dump();
 	file.json = stringified;
 
 


### PR DESCRIPTION
`texture_metadata` was the name of the nlohmann::json instance in `texture_asset.cpp`. This is just a simple copy/paste bug fix when `material_asset.cpp` was written.