### PR TITLE
Adding missing `queueFamilyIndex` to `commandPoolInfo`

### DIFF
--- a/vkguide_new_source/new_chapter_1/vulkan_commands_code.md
+++ b/vkguide_new_source/new_chapter_1/vulkan_commands_code.md
@@ -64,6 +64,7 @@ void VulkanEngine::init_commands()
 	commandPoolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 	commandPoolInfo.pNext = nullptr;
 	commandPoolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+	commandPoolInfo.queueFamilyIndex = _graphicsQueueFamily;
 
 	for (int i = 0; i < FRAME_OVERLAP; i++) {
 


### PR DESCRIPTION
It is mentioned in the text below the code of the section "Creating the Command structures" that we set `queueFamilyIndex` to `_graphicsQueueFamily`, but that change is not reflected in the actual code.