### PR TITLE
fixing cmake error on macos 13

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,12 @@
 
 # Add source to this project's executable.
-add_executable (engine 
+add_executable (engine
   main.cpp
   vk_types.h
   vk_initializers.cpp
   vk_initializers.h
   vk_images.h
-  vk_images.cpp 
+  vk_images.cpp
   vk_descriptors.h
   vk_descriptors.cpp
   vk_pipelines.h
@@ -28,6 +28,6 @@ target_link_libraries(engine PUBLIC vma glm Vulkan::Vulkan fmt::fmt stb_image SD
 target_precompile_headers(engine PUBLIC <optional> <vector> <memory> <string> <vector> <unordered_map> <glm/mat4x4.hpp>  <glm/vec4.hpp> <vulkan/vulkan.h>)
 
 add_custom_command(TARGET engine POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:engine> $<TARGET_FILE_DIR:engine>
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:engine> $<TARGET_FILE_DIR:engine>
   COMMAND_EXPAND_LISTS
   )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(glm INTERFACE glm)
 #target_link_libraries(sdl2 INTERFACE SDL2 SDL2main)
 
 add_library(imgui STATIC)
+set_property(TARGET imgui PROPERTY CXX_STANDARD 20)
 
 target_include_directories(imgui PUBLIC imgui)
 

--- a/third_party/fastgltf/CMakeLists.txt
+++ b/third_party/fastgltf/CMakeLists.txt
@@ -24,7 +24,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler_flags.cmake)
 
 if (FASTGLTF_DOWNLOAD_SIMDJSON)
     # Download and configure simdjson
-    set(SIMDJSON_TARGET_VERSION "3.3.0")
+    set(SIMDJSON_TARGET_VERSION "3.10.0")
     set(SIMDJSON_DL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/simdjson")
     file(MAKE_DIRECTORY ${SIMDJSON_DL_DIR})
 


### PR DESCRIPTION
I am using the m1 version macos 13.4.
Fixing some build issues.

- TARGET_RUNTIME_DLLS is emplty for none DLL platforms
- SIMDJSON and IMGUI have compiler errors.