### PR TITLE
Delete unnecessary vkutil::transition_image

### DIFF
--- a/chapter-5/vk_engine.cpp
+++ b/chapter-5/vk_engine.cpp
@@ -273,8 +273,6 @@ void VulkanEngine::draw_main(VkCommandBuffer cmd)
 
 	//draw the triangle
 
-    vkutil::transition_image(cmd, _drawImage.image, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
 	VkRenderingAttachmentInfo colorAttachment = vkinit::attachment_info(_drawImage.imageView, nullptr, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 	VkRenderingAttachmentInfo depthAttachment = vkinit::depth_attachment_info(_depthImage.imageView, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL);
 


### PR DESCRIPTION
There's an unnecessary unnecessary vkutil::transition_image in the draw_main() function. I removed it, which also stops the validation layers from complaining about the wrong old image layout type