### PR TITLE
Fixed typo in the chapter 3. Mesh loading 

### DIFF
--- a/vkguide_new_source/new_chapter_3/loading_meshes.md
+++ b/vkguide_new_source/new_chapter_3/loading_meshes.md
@@ -61,7 +61,7 @@ Our load function will be this
 std::optional<std::vector<std::shared_ptr<MeshAsset>>> loadGltfMeshes(VulkanEngine* engine, std::filesystem::path filePath);
 ```
 
-This is the first time see see std::optional being used. This is standard class that wraps a type (the vector of mesh assets here) and allows for it to be errored/null. As file loading can fail for many reasons, it returning null is a good idea. We will be using fastGltf library, which uses all of those new stl features for its loading.
+This is the first time we see std::optional being used, which is standard class that wraps a type (the vector of mesh assets here) and allows for it to be errored/null. As file loading can fail for many reasons, it returning null is a good idea. We will be using fastGltf library, which uses all of those new stl features for its loading.
 
 Lets begin by opening the file
 


### PR DESCRIPTION
word _see_ was used instead of  _we_.

