### PR TITLE
Replaced std::deque with std::stack for LIFO Property by Default

### DIFF
--- a/chapter-2/vk_engine.h
+++ b/chapter-2/vk_engine.h
@@ -23,7 +23,8 @@ struct DeletionQueue
 	{
 		while (!deletors.empty())
 		{
-			deletors.top(); 
+			auto topFunc = deletors.top();
+			topFunc(); // call function 
 			deletors.pop(); 
 		}
 	}

--- a/chapter-2/vk_engine.h
+++ b/chapter-2/vk_engine.h
@@ -6,25 +6,26 @@
 #include <vk_types.h>
 #include <vector>
 #include "vk_mem_alloc.h"
-#include <deque>
+#include <stack>
 #include <functional>
 #include "vk_descriptors.h"
 
 struct DeletionQueue 
 {
-	std::deque<std::function<void()>> deletors;
+	std::stack<std::function<void()>> deletors; 
 
-	void push_function(std::function<void()>&& function) {
-		deletors.push_back(function);
+	void push_function(std::function<void()>&& function) 
+	{
+		deletors.push(function); 
 	}
 
-	void flush() {
-		// reverse iterate the deletion queue to execute all the functions
-		for (auto it = deletors.rbegin(); it != deletors.rend(); it++) {
-			(*it)(); //call functors
+	void flush() 
+	{
+		while (!deletors.empty())
+		{
+			deletors.top(); 
+			deletors.pop(); 
 		}
-
-		deletors.clear();
 	}
 };
 


### PR DESCRIPTION
While going through the guide, I saw std::deque was being used as std::stack. From the description it seems stack is exactly what is needed since it's interface follows Last In First Out/First In Last Out by default

Quote from guide: 
`We will be using that deque as a First In Last Out queue, so that when we flush the deletion queue, it first destroys the objects that were added into it last.`

Link to section: 
https://vkguide.dev/docs/new_chapter_2/vulkan_new_rendering/