### PR TITLE
Set feature sType in feature structs

### DIFF
--- a/chapter-5/vk_engine.cpp
+++ b/chapter-5/vk_engine.cpp
@@ -876,11 +876,11 @@ void VulkanEngine::init_vulkan()
 
     SDL_Vulkan_CreateSurface(_window, _instance, &_surface);
 
-    VkPhysicalDeviceVulkan13Features features13 {};
+	VkPhysicalDeviceVulkan13Features features13{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES };
 	features13.dynamicRendering = true;
 	features13.synchronization2 = true;
    
-   VkPhysicalDeviceVulkan12Features features12 {};
+   VkPhysicalDeviceVulkan12Features features12{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES };
    features12.bufferDeviceAddress = true;
    features12.descriptorIndexing = true; 
 

--- a/chapter-6/vk_engine.cpp
+++ b/chapter-6/vk_engine.cpp
@@ -874,13 +874,11 @@ void VulkanEngine::init_vulkan()
 
     SDL_Vulkan_CreateSurface(_window, _instance, &_surface);
 
-    VkPhysicalDeviceVulkan13Features features13 {};
-    features13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+	VkPhysicalDeviceVulkan13Features features13{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES };
 	features13.dynamicRendering = true;
 	features13.synchronization2 = true;
    
-   VkPhysicalDeviceVulkan12Features features12 {};
-   features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+   VkPhysicalDeviceVulkan12Features features12{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES };
    features12.bufferDeviceAddress = true;
    features12.descriptorIndexing = true; 
    features12.descriptorBindingPartiallyBound = true;

--- a/chapter-6/vk_engine.cpp
+++ b/chapter-6/vk_engine.cpp
@@ -875,10 +875,12 @@ void VulkanEngine::init_vulkan()
     SDL_Vulkan_CreateSurface(_window, _instance, &_surface);
 
     VkPhysicalDeviceVulkan13Features features13 {};
+    features13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
 	features13.dynamicRendering = true;
 	features13.synchronization2 = true;
    
    VkPhysicalDeviceVulkan12Features features12 {};
+   features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
    features12.bufferDeviceAddress = true;
    features12.descriptorIndexing = true; 
    features12.descriptorBindingPartiallyBound = true;


### PR DESCRIPTION
Are the all-chapter-2 examples intended to fail as part of the exercise? `chapter_[56]` fails with assertions on `feature_XX.sType` not containing the expected manifest constants. 