### PR TITLE
add fix to src/CMakeLists.txt custom copy command for Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,9 @@ target_link_libraries(engine PUBLIC vma glm Vulkan::Vulkan fmt::fmt stb_image SD
 
 target_precompile_headers(engine PUBLIC <optional> <vector> <memory> <string> <vector> <unordered_map> <glm/mat4x4.hpp>  <glm/vec4.hpp> <vulkan/vulkan.h>)
 
-add_custom_command(TARGET engine POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:engine> $<TARGET_FILE_DIR:engine>
-  COMMAND_EXPAND_LISTS
-  )
+if(WIN32)
+  add_custom_command(TARGET engine POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:engine> $<TARGET_FILE_DIR:engine>
+    COMMAND_EXPAND_LISTS
+    )
+endif()


### PR DESCRIPTION
Add if statement to custom copy command in `src/CMakeLists.txt` to cause a trigger only when on `WIN32` platforms.

This allows for a successful build on the following system:
```
PRETTY_NAME="Ubuntu 24.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.3 LTS (Noble Numbat)"
```
