### PR TITLE
Make font size respect browser settings

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -12,8 +12,8 @@
   background: $link-color;
 }
 
-html {
-  @include fs-4;
+:root {
+  font-size: 1rem;
 }
 
 body {
@@ -86,7 +86,7 @@ a:not([class]) {
 
 code {
   font-family: $mono-font-family;
-  font-size: 12px;
+  font-size: 1em;
   line-height: $body-line-height;
 }
 

--- a/_sass/support/mixins/_typography.scss
+++ b/_sass/support/mixins/_typography.scss
@@ -1,81 +1,101 @@
 // Font size
 
 @mixin fs-1 {
-  font-size: 9px !important;
+  /* 9px/16px = 0.5625rem */
+  font-size: 0.5625rem !important;
 
   @include mq(sm) {
-    font-size: 10px !important;
+    /* 10px/16px = 0.625rem */
+    font-size: 0.625rem !important;
   }
 }
 
 @mixin fs-2 {
-  font-size: 11px !important;
+  /* 11px/16px = 0.6875rem */
+  font-size: 0.6875rem !important;
 
   @include mq(sm) {
-    font-size: 12px !important;
+    /* 12px/16px = 0.75rem */
+    font-size: 0.75rem !important;
   }
 }
 
 @mixin fs-3 {
-  font-size: 12px !important;
+  /* 12px/16px = 0.75rem */
+  font-size: 0.75rem !important;
 
   @include mq(sm) {
-    font-size: 14px !important;
+    /* 14px/16px = 0.875rem */
+    font-size: 0.875rem !important;
   }
 }
 
 @mixin fs-4 {
-  font-size: 14px !important;
+  /* 14px/16px = 0.875rem */
+  font-size: 0.875rem !important;
 
   @include mq(sm) {
-    font-size: 16px !important;
+    /* 16px/16px = 1rem */
+    font-size: 1rem !important;
   }
 }
 
 @mixin fs-5 {
-  font-size: 16px !important;
+  /* 16px/16px = 1rem */
+  font-size: 1rem !important;
 
   @include mq(sm) {
-    font-size: 18px !important;
+    /* 18px/16px = 1.125rem */
+    font-size: 1.125rem !important;
   }
 }
 
 @mixin fs-6 {
-  font-size: 18px !important;
+  /* 18px/16px = 1.125rem */
+  font-size: 1.125rem !important;
 
   @include mq(sm) {
-    font-size: 24px !important;
+    /* 24px/16px = 1.5rem */
+    font-size: 1.5rem !important;
   }
 }
 
 @mixin fs-7 {
-  font-size: 24px !important;
+  /* 24px/16px = 1.5rem */
+  font-size: 1.5rem !important;
 
   @include mq(sm) {
-    font-size: 32px !important;
+    /* 32px/16px = 2rem */
+    font-size: 2rem !important;
   }
 }
 
 @mixin fs-8 {
-  font-size: 32px !important;
+  /* 32px/16px = 2rem */
+  font-size: 2rem !important;
 
   @include mq(sm) {
-    font-size: 36px !important;
+    /* 36px/16px = 2.25rem */
+    font-size: 2.25rem !important;
   }
 }
 
 @mixin fs-9 {
-  font-size: 36px !important;
+  /* 36px/16px = 2.25rem */
+  font-size: 2.25rem !important;
 
   @include mq(sm) {
-    font-size: 42px !important;
+    /* 42px/16px = 2.625rem */
+    font-size: 2.625rem !important;
   }
 }
 
 @mixin fs-10 {
-  font-size: 42px !important;
+  /* 42px/16px = 2.625rem */
+  font-size: 2.625rem !important;
 
   @include mq(sm) {
-    font-size: 48px !important;
+    /* 48px/16px = 3rem */
+    font-size: 3rem !important;
   }
 }


### PR DESCRIPTION
The font size in my browser is set to 20px (I am blind, I know), but due to the font size being hardcoded as a constant pixel value in the css, my settings are overwritten and the text appears small.

This commit mitigates that issue by replacing all fixed size font sizes with rem units that depend on the browser-provided font size.