### PR TITLE
fix bottom of text being cut off in code blocks

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -86,8 +86,14 @@ a:not([class]) {
 
 code {
   font-family: $mono-font-family;
-  font-size: 1em;
-  line-height: $body-line-height;
+  font-size: 1rem;
+  /* This was set to $body-line-height, but normal is a sane default. We could
+   * restore the previous value if the lines end up being too narrow. */
+  line-height: normal;
+
+  background-color: $code-background-color;
+  border: $border $border-color;
+  border-radius: $border-radius;
 }
 
 figure,

--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -3,17 +3,6 @@
 //
 // stylelint-disable selector-no-qualifying-type, declaration-block-semicolon-newline-after,declaration-block-single-line-max-declarations, selector-no-type, selector-max-type
 
-code {
-  
-  padding: 0.0em 0.0em;
-  font-weight: 400;
-  background-color: $code-background-color;
-  border: $border $border-color;
-  border-radius: $border-radius;
-  line-height: 1.0;
-  tab-size: 4;
-}
-
 pre.highlight,
 figure.highlight {
   padding: $sp-3;
@@ -21,10 +10,7 @@ figure.highlight {
   -webkit-overflow-scrolling: touch;
   background-color: $code-background-color;
   tab-size: 4;
-  line-height: 1.0;
   code {
-    tab-size: 4;
-    line-height: 1.0;
     padding: 0;
     border: 0;
   }
@@ -254,12 +240,10 @@ figure.highlight {
   overflow: auto;
   border: 1px solid $border-color;
   border-radius: $border-radius;
-  line-height: 1;
   tab-size: 4;
   + .highlighter-rouge,
   + figure.highlight {
     tab-size: 4;
-    line-height: 1.0;
     position: relative;
     margin-top: -$sp-4;
     border-right: 1px solid $border-color;


### PR DESCRIPTION
The bottom of every line of text in code blocks was cut off due to insufficiently large line-height.

Fix by changing the line-height to 'normal'. The browsers should infer the correct size required for a font to be properly rendered.

Fixes #158.