### PR TITLE
Prefer simdjson from system if found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project ("vulkan_guide")
 
 
 find_package(Vulkan REQUIRED)
+find_package(simdjson QUIET)
+if (simdjson_FOUND)
+  set(FASTGLTF_DOWNLOAD_SIMDJSON OFF CACHE BOOL "" FORCE)
+endif()
 
 add_subdirectory(third_party)
 


### PR DESCRIPTION
The bundled version is quite old and fails to build on ubuntu 25.04 / g++14. Error was:
```
simdjson/simdjson.cpp:16640:49: error: inlining failed in call to
   ‘always_inline’ ‘simdjson::error_code
   imdjson::fallback::{anonymous}::stage2::json_iterator::walk_document(V&) noexcept
   [with bool STREAMING = false;
   V = simdjson::fallback::{anonymous}::stage2::tape_builder]’:
   target specific option mismatch
   ```